### PR TITLE
Improvements for search grid

### DIFF
--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -70,7 +70,7 @@ const ImageProviderService = {
           url: 'https://www.metmuseum.org',
           logo: 'mccordmuseum_logo.png',
         },
-      museumvictoria:
+      museumsvictoria:
         { name: 'Museums Victoria',
           url: 'https://collections.museumvictoria.com.au',
           logo: 'museumvictoria_logo.svg',

--- a/src/components/SearchGrid.vue
+++ b/src/components/SearchGrid.vue
@@ -1,13 +1,25 @@
 <template>
-  <section class='search-grid'>
-    <div class="grid-x">
-      <div class="search-grid_analytics cell medium-6 large-6" v-if="showGrid && includeAnalytics">
-        <span>{{ _imagesCount }}</span>
-        <span>{{ searchTerm }}</span>
-        Photos
+  <section :class="{ 'search-grid': true, 'search-grid__contain-images': shouldContainImages }"
+           ref="searchGrid">
+    <div class="grid-x" v-show="showGrid && includeAnalytics">
+      <div class="search-grid_analytics cell medium-6 large-6" >
+        <h5>
+          <span>{{ _imagesCount }}</span>
+          <span>{{ searchTerm }}</span>
+          Photos
+        </h5>
       </div>
-      <div class="search-grid_layout-control">
-        Grid Options:
+      <div class="search-grid_layout-control cell medium-6 large-6">
+        <h5>Grid Options:</h5>
+        <fieldset>
+          <input
+            id="watermark"
+            type="checkbox"
+            v-model="shouldContainImages">
+            <label for="watermark">
+              Contain image
+            </label>
+        </fieldset>
       </div>
     </div>
     <ul class="search-grid_metrics-bar">
@@ -80,6 +92,7 @@ export default {
   },
   data: () => ({
     isDataInitialized: false,
+    shouldContainImages: false,
     currentPage: 1,
     showGrid: false,
   }),
@@ -213,13 +226,29 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style lang="scss" scoped>
-  .infinite-loading-container {
-    margin-top: 30px;
-    width: 100%;
+
+  .search-grid_analytics h5,
+  .search-grid_layout-control h5 {
+    font-size: 1rem;
+    display: inline-block;
+  }
+
+  .search-grid_layout-control h5 {
+    margin-right: 10px;
   }
 
   .search-grid_layout-control {
-    display: none;
+    text-align: right;
+
+    fieldset {
+      display: inline;
+      margin-right: 5px;
+    }
+  }
+
+  .infinite-loading-container {
+    margin-top: 30px;
+    width: 100%;
   }
 
   .search-grid_image-ctr {
@@ -386,6 +415,10 @@ export default {
     transform: translate(-50%, -50%);
   }
 
+  .search-grid__contain-images .search-grid_image{
+    max-height: 100%;
+  }
+
   .search-grid_notification {
     width: 50%;
     margin: auto;
@@ -426,6 +459,10 @@ export default {
       width:  44px;
       height: 44px;
       bottom: 0;
+    }
+
+     .search-grid_layout-control {
+      text-align: left !important;
     }
   }
 </style>

--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -142,7 +142,7 @@ export default {
         { code: 'iha', name: 'IHA Holiday Ads' },
         { code: 'mccordmuseum', name: 'Montreal Social History Museum' },
         { code: 'met', name: 'Metropolitan Museum of Art' },
-        { code: 'museumvictoria', name: 'Museums Victoria' },
+        { code: 'museumsvictoria', name: 'Museums Victoria' },
         { code: 'nypl', name: 'New York Public Library' },
         { code: 'rijksmuseum', name: 'Rijksmuseum NL' },
         { code: 'sciencemuseum', name: 'Science Museum – UK' },

--- a/src/store/image-provider-store.js
+++ b/src/store/image-provider-store.js
@@ -19,7 +19,7 @@ const state = {
 
 const actions = {
   [FETCH_IMAGE_STATS]({ commit }, params) {
-    commit(SET_FETCH_IMAGES_ERROR, { isFetchingImageStatsError: true });
+    commit(SET_FETCH_IMAGES_ERROR, { isFetchingImageStatsError: false });
     commit(FETCH_IMAGE_STATS_START);
     return ImageProviderService.getProviderStats(params)
       .then(({ data }) => {


### PR DESCRIPTION
This PR does the following: 

- Fixes issue with `Museums Victoria` provider, when filtering.
- Adds the ability to contain images, so they aren't cropped within the search grid.
- Fixes issues displaying error code, when retrieving provider stats.
