### PR TITLE
Fix Google Analytics not being configured for an SPA (#116)

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,17 +48,18 @@
       <div id="app"></div>
 
       <script>
-        if (document.location.hostname.indexOf('ccsearch') != -1) {
-          /* eslint-disable */
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+		// Use production Google Analytics ID if ccsearch is in the URL, otherwise use development/staging ID
+		// TODO: Refactor this to use environment variables instead of hardcoding IDs here.
+		var gaID = document.location.hostname.indexOf('ccsearch') == -1 ? 'UA-2010376-36' : 'UA-2010376-33';
+        /* eslint-disable */
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-          ga('create', 'UA-2010376-33', 'auto');
-          ga('send', 'pageview');
-           /* eslint-enable */
-        }
+        ga('create', gaID, 'auto');
+        ga('send', 'pageview');
+        /* eslint-enable */
       </script>
 
     </body>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -60,6 +60,8 @@ router.afterEach((to) => {
   }
   store.commit(SET_IMAGE, { image: {} });
   store.commit(SET_IMAGES, { images: [] });
+  window.ga('set', 'page', to.path);
+  window.ga('send', 'pageview');
 });
 
 export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -60,8 +60,11 @@ router.afterEach((to) => {
   }
   store.commit(SET_IMAGE, { image: {} });
   store.commit(SET_IMAGES, { images: [] });
-  window.ga('set', 'page', to.path);
-  window.ga('send', 'pageview');
+
+  /* eslint-disable */
+  ga('set', 'page', to.path);
+  ga('send', 'pageview');
+  /* eslint-enable */
 });
 
 export default router;


### PR DESCRIPTION
Google Analytics now updates the URL recorded and sends a new pageview when a user navigates within the single page app.

## Changes
- Set up a separate Google Analytics ID for development/staging and used it conditionally so that Google Analytics can be tested locally.
- Updated URL sent to Google Analytics and logged a new pageview when the Vue Router navigates to a new route.
- Disabled linting of Google Analytics code.

## Testing

Tested by visiting pages locally and made sure Google Analytics was showing the correct URL (e.g. `/photos/559a18bc-2e9d-4d7a-8a9c-ba522cb1498d` in the Real-Time stats.

## Screenshots
List of pages from production Google Analytics data:
<img width="2032" alt="screen shot 2018-12-07 at 9 43 22 pm" src="https://user-images.githubusercontent.com/287034/49681068-df51f300-fa69-11e8-9b90-f26e60a293df.png">

Page visit data when I was testing locally:
<img width="2032" alt="screen shot 2018-12-07 at 9 44 12 pm" src="https://user-images.githubusercontent.com/287034/49681086-06102980-fa6a-11e8-87cc-490a47c6b4eb.png">

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

