### PR TITLE
Add visual indication of success when using "Copy" buttons

### DIFF
--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -35,6 +35,7 @@ export default {
   destroyed() {
     // unattach our clipboard instance when component is destroyed
     this.clipboard.destroy();
+    this.clipboard = null;
   },
 };
 </script>

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -1,0 +1,48 @@
+<template>
+  <button type="button"
+          class="button photo_copy-btn">
+    <slot v-if="!success" default />
+    <template v-if="success">Copied!</template>
+  </button>
+</template>
+
+<script>
+import Clipboard from 'clipboard';
+
+export default {
+  data: () => ({
+    clipboard: null,
+    success: false,
+  }),
+  props: {
+    toCopy: {
+      required: true,
+    },
+  },
+  mounted() {
+    this.clipboard = new Clipboard(this.$el, {
+      // eslint-disable-line no-new
+      text: () => this.toCopy.replace(/\s\s/g, ''),
+    });
+
+    this.clipboard.on('success', () => {
+      this.success = true;
+      setTimeout(() => {
+        this.success = false;
+      }, 2000);
+    });
+  },
+  destroyed() {
+    // unattach our clipboard instance when component is destroyed
+    this.clipboard.destroy();
+  },
+};
+</script>
+
+<style scoped>
+  .photo_copy-btn {
+    border-radius: 3px;
+    width: 49%;
+    background: #4a69ca;
+  }
+</style>

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -2,7 +2,7 @@
   <button type="button"
           class="button photo_copy-btn">
     <slot v-if="!success" default />
-    <template v-if="success">Copied!</template>
+    <template v-else>Copied!</template>
   </button>
 </template>
 
@@ -21,7 +21,6 @@ export default {
   },
   mounted() {
     this.clipboard = new Clipboard(this.$el, {
-      // eslint-disable-line no-new
       text: () => this.toCopy.replace(/\s\s/g, ''),
     });
 

--- a/src/pages/PhotoDetailPage.vue
+++ b/src/pages/PhotoDetailPage.vue
@@ -66,16 +66,8 @@
               CC {{ image.license}} {{ image.license_version }}
               </a>
             </p>
-            <button class="button photo_copy-btn
-              photo_copy-btn__html"
-              data-type="html">
-            Copy to HTML</button>
-            <button class="button
-              photo_copy-btn
-              photo_copy-btn__text"
-              data-type="text">
-            Copy to Text
-            </button>
+            <CopyButton :toCopy="HTMLAttribution">Copy to HTML</CopyButton>
+            <CopyButton :toCopy="textAttribution">Copy to Text</CopyButton>
           </section>
       </div>
     </div>
@@ -129,12 +121,12 @@
 </template>
 
 <script>
+import CopyButton from '@/components/CopyButton';
 import HeaderSection from '@/components/HeaderSection';
 import FooterSection from '@/components/FooterSection';
 import SearchGrid from '@/components/SearchGrid';
 import LicenseIcons from '@/components/LicenseIcons';
 import { FETCH_IMAGE, FETCH_RELATED_IMAGES } from '@/store/action-types';
-import Clipboard from 'clipboard';
 import 'viewerjs/dist/viewer.css';
 import Viewer from 'v-viewer';
 import Vue from 'vue';
@@ -145,6 +137,7 @@ Vue.use(Viewer);
 const PhotoDetailPage = {
   name: 'photo-detail-page',
   components: {
+    CopyButton,
     HeaderSection,
     SearchGrid,
     FooterSection,
@@ -272,20 +265,6 @@ const PhotoDetailPage = {
         this.$store.dispatch(FETCH_RELATED_IMAGES, { q: queryParam, pagesize: 8 });
       }
     },
-    initClipboard() {
-      new Clipboard('.photo_copy-btn', { // eslint-disable-line no-new
-        text: (element) => {
-          let attributionContent;
-          if (element.getAttribute('data-type') === 'html') {
-            attributionContent = this.HTMLAttribution;
-          } else {
-            attributionContent = this.textAttribution;
-          }
-
-          return attributionContent.replace(/\s\s/g, '');
-        },
-      });
-    },
     isClarifaiTag(provider) {
       let isClarifaiTag = false;
 
@@ -326,7 +305,6 @@ const PhotoDetailPage = {
   },
   created() {
     this.loadImage(this.$route.params.id);
-    this.initClipboard();
   },
 };
 
@@ -535,18 +513,5 @@ export default PhotoDetailPage;
     border-left: 1px solid #e7e8e9;;
     padding-left: 10px;
     padding-bottom: 15px
-  }
-
-  .photo_copy-btn {
-    border-radius: 3px;
-    width: 49%;
-  }
-
-  .photo_copy-btn__html {
-    background: #4A69CA;
-  }
-
-  .photo_copy-btn__text {
-    background: #4A69CA;
   }
 </style>


### PR DESCRIPTION
Currently the "Copy to HTML" and "Copy to Text" buttons on the Photo detail pages ([example here](https://ccsearch.creativecommons.org/photos/2a5ff4cd-7be0-4fd7-bafd-dace875f1874)) offer no indication that text has actually been copied. 

This PR adds "Copied!" text to the copy buttons after the text is successfully copied:

![button-feedback-preview](https://user-images.githubusercontent.com/6351754/49693007-61a7e900-fb36-11e8-8fa5-28ded612b96c.gif)

Live Demo: https://dist-cwpsijvzyr.now.sh/ (visit any image detail page)

It also extracts the copy button logic from `PhotoDetailPage.vue`into a standalone component and [simplifies previous logic](https://github.com/creativecommons/cccatalog-frontend/blob/531e2583276bfd1e8064f2d7aec8155f60ac8975/src/pages/PhotoDetailPage.vue#L279) for adding _new_ "Copy" buttons in the future (relevant to: #106).

```vue
// Accepts a single prop for the text to be copied
// displays "Copied!" for 2s after successful copy
<CopyButton :toCopy="HTMLAttribution">Copy to HTML</CopyButton>
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

