### PR TITLE
Update setup documentation about HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # install dependencies
 npm install
 
-# serve with hot reload at localhost:8080
+# serve with hot reload at https://localhost:8080 (important: it runs on https://, not http://)
 npm run dev
 
 # build for production with minification

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # install dependencies
 npm install
 
-# serve with hot reload at https://localhost:8080 (important: it runs on https://, not http://)
+# serve with hot reload at https://localhost:8443 (important: it runs on https://, not http://)
 npm run dev
 
 # build for production with minification

--- a/build/webpack-dev-conf.js
+++ b/build/webpack-dev-conf.js
@@ -82,7 +82,7 @@ module.exports = new Promise((resolve, reject) => {
       // Add FriendlyErrorsPlugin
       devWebpackConfig.plugins.push(new FriendlyErrorsPlugin({
         compilationSuccessInfo: {
-          messages: [`Your application is running here: http://${devWebpackConfig.devServer.host}:${port}`],
+          messages: [`Your application is running here: https://${devWebpackConfig.devServer.host}:${port}`],
         },
         onErrors: config.dev.notifyOnErrors
         ? utils.createNotifierCallback()

--- a/config/index.js
+++ b/config/index.js
@@ -14,7 +14,7 @@ module.exports = {
 
     // Various Dev Server settings
     host: 'localhost', // can be overwritten by process.env.HOST
-    port: 8080, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
+    port: 8443, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
     autoOpenBrowser: false,
     errorOverlay: true,
     notifyOnErrors: true,

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -4,7 +4,7 @@
 module.exports = {
   'default e2e tests': function test(browser) {
     // automatically uses dev Server port from /config.index.js
-    // default: http://localhost:8080
+    // default: http://localhost:8443
     // see nightwatch.conf.js
     const devServer = browser.globals.devServerURL;
 


### PR DESCRIPTION
This PR updates the documentation and the webpack output with a notice about the application running on HTTPS instead of HTTP. This way, people new to the codebase won't be lost when they try to access it on http://localhost:8080/ and see nothing being served

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

