### PR TITLE
Sends search params to GA page command

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -61,7 +61,7 @@ router.afterEach((to) => {
   store.commit(SET_IMAGE, { image: {} });
   store.commit(SET_IMAGES, { images: [] });
 
-  ga('set', 'page', to.path);
+  ga('set', 'page', to.fullPath);
   ga('send', 'pageview');
 });
 


### PR DESCRIPTION
Instead of sending only the relative URL to the `page` command of GA, this change sends the query string parameters as well. This allows the analytics to collect which terms are being searched for.

Example:

Before the URL sent to the `page` command was `/search`.

Now it sends `/search?q=landscapes`


## Screenshots

![screen shot 2019-01-09 at 12 26 23](https://user-images.githubusercontent.com/707019/50905415-ee7de500-1409-11e9-8f36-0e320ff611b3.png)

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

