### PR TITLE
Adds new providers to search filters

### DIFF
--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -133,6 +133,8 @@ export default {
         { code: '500px', name: '500px' },
         { code: 'animaldiversity', name: 'Animal Diversity Web' },
         { code: 'behance', name: 'Behance' },
+        { code: 'brooklynmuseum', name: 'Brooklyn Museum' },
+        { code: 'clevelandmuseum', name: 'Cleveland Museum of Art' },
         { code: 'deviantart', name: 'DeviantArt' },
         { code: 'digitaltmuseum', name: 'Digitalt Museum' },
         { code: 'eol', name: 'Encyclopedia of Life' },
@@ -143,9 +145,12 @@ export default {
         { code: 'mccordmuseum', name: 'Montreal Social History Museum' },
         { code: 'met', name: 'Metropolitan Museum of Art' },
         { code: 'museumsvictoria', name: 'Museums Victoria' },
+        { code: 'nhl', name: 'TODO' },
         { code: 'nypl', name: 'New York Public Library' },
         { code: 'rijksmuseum', name: 'Rijksmuseum NL' },
         { code: 'sciencemuseum', name: 'Science Museum – UK' },
+        { code: 'thingiverse', name: 'Thingiverse' },
+        { code: 'WoRMS', name: 'World Register of Marine Species' },
       ],
     licenses:
       [

--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -145,7 +145,7 @@ export default {
         { code: 'mccordmuseum', name: 'Montreal Social History Museum' },
         { code: 'met', name: 'Metropolitan Museum of Art' },
         { code: 'museumsvictoria', name: 'Museums Victoria' },
-        { code: 'nhl', name: 'TODO' },
+        { code: 'nhl', name: 'London Natural History Museum' },
         { code: 'nypl', name: 'New York Public Library' },
         { code: 'rijksmuseum', name: 'Rijksmuseum NL' },
         { code: 'sciencemuseum', name: 'Science Museum – UK' },


### PR DESCRIPTION
Fixes #139 by adding the Cleveland Museum of Art and a few others that still hadn't been added to the filter list, but had their works already added to our database, according to http://api.creativecommons.engineering/statistics/image.

## Todos
There's a provider with code `nhl` that I don't know the full name.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

