### PR TITLE
Add new providers to about page

### DIFF
--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -86,8 +86,8 @@ const ImageProviderService = {
         logo: 'museumvictoria_logo.svg',
       },
       nhl: {
-        name: 'TODO',
-        url: 'https://TODO.org',
+        name: 'Natural History Museum in London',
+        url: 'http://www.nhm.ac.uk/',
         logo: '',
       },
       nypl: {

--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -10,86 +10,111 @@ const ImageProviderService = {
   },
   getProviderInfo(providerName) {
     const PROVIDER_NAME_LOOKUP = {
-      '500px':
-        { name: '500px',
-          url: 'https://500px.com',
-          logo: '500px_logo.png',
-        },
-      animaldiversity:
-        { name: 'Animal Diversity Web',
-          url: 'https://animaldiversity.org',
-          logo: 'animaldiversity_logo.png',
-        },
-      behance:
-        { name: 'Behance',
-          url: 'https://www.behance.net',
-          logo: 'behance_logo.svg',
-        },
-      deviantart:
-        { name: 'DeviantArt',
-          url: 'https://www.deviantart.com',
-          logo: 'deviantart_logo.png',
-        },
-      digitaltmuseum:
-        { name: 'Digitalt Museum',
-          url: 'https://digitaltmuseum.org',
-          logo: 'digitaltmuseum_logo.png',
-        },
-      eol:
-        { name: 'Encyclopedia of Life',
-          url: 'http://eol.org',
-          logo: 'eol_logo.png',
-        },
-      flickr:
-        { name: 'Flickr',
-          url: 'https://www.flickr.com',
-          logo: 'flickr_icon.png',
-        },
-      floraon:
-        { name: 'Flora-On',
-          url: 'http://flora-on.pt',
-          logo: 'floraon_logo.png',
-        },
-      geographorguk:
-        { name: 'Geograph® Britain and Ireland',
-          url: 'https://www.geograph.org.uk',
-          logo: 'geographorguk_logo.gif',
-        },
-      iha:
-        { name: 'IHA Holiday Ads',
-          url: 'https://www.iha.com',
-          logo: 'iha_logo.png',
-        },
-      mccordmuseum:
-        { name: 'Montreal Social History Museum',
-          url: 'https://www.musee-mccord.qc.ca/en/',
-          logo: 'mccordmuseum_logo.png',
-        },
-      met:
-        { name: 'Metropolitan Museum of Art',
-          url: 'https://www.metmuseum.org',
-          logo: 'mccordmuseum_logo.png',
-        },
-      museumsvictoria:
-        { name: 'Museums Victoria',
-          url: 'https://collections.museumvictoria.com.au',
-          logo: 'museumvictoria_logo.svg',
-        },
-      nypl:
-        { name: 'New York Public Library',
-          url: 'https://www.nypl.org',
-          logo: 'nypl_logo.svg',
-        },
-      rijksmuseum:
-        { name: 'Rijksmuseum NL',
-          url: 'https://www.rijksmuseum.nl/en/',
-          logo: 'rijksmuseum_logo.png',
-        },
-      sciencemuseum:
-        { name: 'Science Museum – UK',
-          url: 'https://www.sciencemuseum.org.uk',
-          logo: 'sciencemuseum_logo.svg',
-        },
+      '500px': {
+        name: '500px',
+        url: 'https://500px.com',
+        logo: '500px_logo.png',
+      },
+      animaldiversity: {
+        name: 'Animal Diversity Web',
+        url: 'https://animaldiversity.org',
+        logo: 'animaldiversity_logo.png',
+      },
+      behance: {
+        name: 'Behance',
+        url: 'https://www.behance.net',
+        logo: 'behance_logo.svg',
+      },
+      brooklynmuseum: {
+        name: 'Brooklyn Museum',
+        url: 'https://www.brooklynmuseum.org/',
+        logo: '',
+      },
+      clevelandmuseum: {
+        name: 'Cleveland Museum of Art',
+        url: 'http://www.clevelandart.org/',
+        logo: '',
+      },
+      deviantart: {
+        name: 'DeviantArt',
+        url: 'https://www.deviantart.com',
+        logo: 'deviantart_logo.png',
+      },
+      digitaltmuseum: {
+        name: 'Digitalt Museum',
+        url: 'https://digitaltmuseum.org',
+        logo: 'digitaltmuseum_logo.png',
+      },
+      eol: {
+        name: 'Encyclopedia of Life',
+        url: 'http://eol.org',
+        logo: 'eol_logo.png',
+      },
+      flickr: {
+        name: 'Flickr',
+        url: 'https://www.flickr.com',
+        logo: 'flickr_icon.png',
+      },
+      floraon: {
+        name: 'Flora-On',
+        url: 'http://flora-on.pt',
+        logo: 'floraon_logo.png',
+      },
+      geographorguk: {
+        name: 'Geograph® Britain and Ireland',
+        url: 'https://www.geograph.org.uk',
+        logo: 'geographorguk_logo.gif',
+      },
+      iha: {
+        name: 'IHA Holiday Ads',
+        url: 'https://www.iha.com',
+        logo: 'iha_logo.png',
+      },
+      mccordmuseum: {
+        name: 'Montreal Social History Museum',
+        url: 'https://www.musee-mccord.qc.ca/en/',
+        logo: 'mccordmuseum_logo.png',
+      },
+      met: {
+        name: 'Metropolitan Museum of Art',
+        url: 'https://www.metmuseum.org',
+        logo: 'mccordmuseum_logo.png',
+      },
+      museumsvictoria: {
+        name: 'Museums Victoria',
+        url: 'https://collections.museumvictoria.com.au',
+        logo: 'museumvictoria_logo.svg',
+      },
+      nhl: {
+        name: 'TODO',
+        url: 'https://TODO.org',
+        logo: '',
+      },
+      nypl: {
+        name: 'New York Public Library',
+        url: 'https://www.nypl.org',
+        logo: 'nypl_logo.svg',
+      },
+      rijksmuseum: {
+        name: 'Rijksmuseum NL',
+        url: 'https://www.rijksmuseum.nl/en/',
+        logo: 'rijksmuseum_logo.png',
+      },
+      sciencemuseum: {
+        name: 'Science Museum – UK',
+        url: 'https://www.sciencemuseum.org.uk',
+        logo: 'sciencemuseum_logo.svg',
+      },
+      thingiverse: {
+        name: 'Thingiverse',
+        url: 'https://www.thingiverse.com/',
+        logo: '',
+      },
+      WoRMS: {
+        name: 'World Register of Marine Species',
+        url: 'http://www.marinespecies.org/',
+        logo: '',
+      },
     };
 
     return PROVIDER_NAME_LOOKUP[providerName];

--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -86,7 +86,7 @@ const ImageProviderService = {
         logo: 'museumvictoria_logo.svg',
       },
       nhl: {
-        name: 'Natural History Museum in London',
+        name: 'London Natural History Museum',
         url: 'http://www.nhm.ac.uk/',
         logo: '',
       },


### PR DESCRIPTION
Adds the new providers to the about page

## Todos
- There's a provider with code `nhl` that I don't know the full name and URL.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

