### PR TITLE
Fix call to toUpperCase on undefined value on render

### DIFF
--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -21,7 +21,7 @@ export default {
   },
   mounted() {
     this.clipboard = new Clipboard(this.$el, {
-      text: () => this.toCopy.replace(/\s\s/g, ''),
+      text: () => this.toCopy().replace(/\s\s/g, ''),
     });
 
     this.clipboard.on('success', () => {

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -6,7 +6,7 @@
            @click.prevent="onGoBackToSearchResults"
            v-if="shouldShowBreadcrumb">&#171; Back to search results</a>
         <img @load="onImageLoad"
-             :class="photo_image"
+             class="photo_image"
              :src="image.url"
              :alt="image.title">
       </div>
@@ -103,26 +103,30 @@ export default {
       return url;
     },
     textAttribution() {
-      const image = this.image;
-      const licenseURL =
-        `<a href="${this.ccLicenseURL}">
-          CC ${image.license.toUpperCase()} ${image.license_version}
-         </a>`;
+      return () => {
+        const image = this.image;
+        const licenseURL =
+          `<a href="${this.ccLicenseURL}">
+            CC ${image.license.toUpperCase()} ${image.license_version}
+          </a>`;
 
-      return `"${image.title}" by ${image.creator}
-              is licensed under CC ${image.license.toUpperCase()}
-              ${image.license_version} ${licenseURL}`;
+        return `"${image.title}" by ${image.creator}
+                is licensed under CC ${image.license.toUpperCase()}
+                ${image.license_version} ${licenseURL}`;
+      };
     },
     HTMLAttribution() {
-      const image = this.image;
+      return () => {
+        const image = this.image;
 
-      return `<a href="${image.foreign_landing_url}">"${image.title}"</a>
-              by
-              <a href="${image.creator_url}">${image.creator}</a>
-              is licensed under
-              <a href="${this.ccLicenseURL}">
-                CC ${image.license.toUpperCase()} ${image.license_version}
-              </a>`;
+        return `<a href="${image.foreign_landing_url}">"${image.title}"</a>
+                by
+                <a href="${image.creator_url}">${image.creator}</a>
+                is licensed under
+                <a href="${this.ccLicenseURL}">
+                  CC ${image.license.toUpperCase()} ${image.license_version}
+                </a>`;
+      };
     },
   },
   methods: {


### PR DESCRIPTION
This fixes a bug on the details page that was caused by eager evaluation of these functions:

https://github.com/creativecommons/cccatalog-frontend/blob/master/src/components/PhotoDetails.vue#L105
and 
https://github.com/creativecommons/cccatalog-frontend/blob/master/src/components/PhotoDetails.vue#L116

This changes it to a lazy evaluation so that it's not called when the image hasn't finished loading.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

