### PR TITLE
Remove HTML tag on  copy to text button click

### DIFF
--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -105,14 +105,11 @@ export default {
     textAttribution() {
       return () => {
         const image = this.image;
-        const licenseURL =
-          `<a href="${this.ccLicenseURL}">
-            CC ${image.license.toUpperCase()} ${image.license_version}
-          </a>`;
+        const licenseURL = this.ccLicenseURL;
 
         return `"${image.title}" by ${image.creator}
                 is licensed under CC ${image.license.toUpperCase()}
-                ${image.license_version} ${licenseURL}`;
+                ${image.license_version}. To view a copy of this license, visit: ${licenseURL}`;
       };
     },
     HTMLAttribution() {


### PR DESCRIPTION
Fixes #105 Removes the `<a>` HTML tag that was added to the text when the user clicked the "Copy to text" button on the image details page

The copied text now is, for example:

> "Released to Public: Hubble Looks at Monocerotis by NASA, ESA, and Hubble Heritage Team(NASA)" by pingnews.com is licensed under CC PDM 1.0. To view a copy of this license, visit: https://creativecommons.org/publicdomain/mark/1.0/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

