### PR TITLE
Show provider full name in photo details page

### DIFF
--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -39,7 +39,7 @@
             <a class="photo_provider"
                :href="image.foreign_landing_url"
                target="blank"
-               rel="noopener noreferrer">{{ image.provider }}</a>
+               rel="noopener noreferrer">{{ providerName }}</a>
           </li>
           <li>
             <h3>Dimensions</h3>
@@ -80,6 +80,13 @@ export default {
     LicenseIcons,
   },
   computed: {
+    providerName() {
+      if (!this.image && !this.image.provider) {
+        return '';
+      }
+
+      return this.image.provider.name;
+    },
     ccLicenseURL() {
       if (!this.image) {
         return '';

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -81,7 +81,7 @@ export default {
   },
   computed: {
     providerName() {
-      if (!this.image && !this.image.provider) {
+      if (!this.image || !this.image.provider) {
         return '';
       }
 

--- a/src/store/search-store.js
+++ b/src/store/search-store.js
@@ -15,6 +15,7 @@ import {
   SET_QUERY,
   SET_RELATED_IMAGES,
 } from './mutation-types';
+import ImageProviderService from '../api/ImageProviderService';
 
 const state = {
   image: {},
@@ -97,7 +98,11 @@ const mutations = {
     _state.isFetchingImages = false;
   },
   [SET_IMAGE](_state, params) {
-    _state.image = params.image;
+    const image = {
+      ...params.image,
+      provider: params.image ? ImageProviderService.getProviderInfo(params.image.provider) : null,
+    };
+    _state.image = image;
   },
   [SET_FILTER_IS_VISIBLE](_state, params) {
     _state.isFilterVisible = params.isFilterVisible;


### PR DESCRIPTION
This provides a quick temporary fix to show the provider full name, at least while the backend API doesn't support sending the provider details.

<img width="412" alt="screen shot 2019-01-18 at 14 47 46" src="https://user-images.githubusercontent.com/707019/51402878-e0307700-1b35-11e9-8e31-3c5cba8313e3.png">
<img width="403" alt="screen shot 2019-01-18 at 14 49 43" src="https://user-images.githubusercontent.com/707019/51402879-e0c90d80-1b35-11e9-93c0-1a5eca3cf84f.png">


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

