### PR TITLE
Fix width of category label on home page

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -237,7 +237,7 @@ $vert-seperate: 4rem;
   padding: 0.5rem;
   position: absolute;
   top: 25%;
-  width: 75%;
+  width: 16.85em;
   z-index: 10;
 }
 


### PR DESCRIPTION
Fixes #156 so the label background doesn't become larger than the image.

![fix label](https://user-images.githubusercontent.com/707019/51487205-d8691080-1d89-11e9-9978-61b8180d1c1c.gif)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

