### PR TITLE
Fix minor bugs on image details page

### DIFF
--- a/src/components/PhotoTags.vue
+++ b/src/components/PhotoTags.vue
@@ -30,16 +30,14 @@
 export default {
   name: 'photo-tags',
   props: ['tags'],
+  computed: {
+    hasClarifaiTags() {
+      return this.$props.tags.some(tag => tag.provider === 'clarifai');
+    },
+  },
   methods: {
     isClarifaiTag(provider) {
-      let isClarifaiTag = false;
-
-      if (provider === 'clarifai') {
-        isClarifaiTag = true;
-        this.hasClarifaiTags = true;
-      }
-
-      return isClarifaiTag;
+      return provider === 'clarifai';
     },
     searchByTagName(query) {
       this.$router.push({ name: 'browse-page', query: { q: query } });

--- a/src/pages/PhotoDetailPage.vue
+++ b/src/pages/PhotoDetailPage.vue
@@ -82,10 +82,12 @@ const PhotoDetailPage = {
     },
   },
   beforeRouteUpdate(to, from, next) {
-    this.imageHeight = 0;
-    this.imageWidth = 0;
-    this.$store.commit(SET_IMAGE, { image: {} });
+    this.resetImageOnRouteChanged();
     this.loadImage(to.params.id);
+    next();
+  },
+  beforeRouteLeave(to, from, next) {
+    this.resetImageOnRouteChanged();
     next();
   },
   beforeRouteEnter(to, previousPage, nextPage) {
@@ -97,6 +99,11 @@ const PhotoDetailPage = {
     });
   },
   methods: {
+    resetImageOnRouteChanged() {
+      this.imageHeight = 0;
+      this.imageWidth = 0;
+      this.$store.commit(SET_IMAGE, { image: {} });
+    },
     onImageLoaded(event) {
       this.imageWidth = event.target.naturalWidth;
       this.imageHeight = event.target.naturalHeight;


### PR DESCRIPTION
This fixes a few minor bugs in the image details page, including an undefined value that was causing some errors to be thrown and a bug that caused the a previous image to be still visible when visualizing another image (see GIFs below).

![bug](https://user-images.githubusercontent.com/707019/53494187-ecd0b500-3a7b-11e9-819f-ab68fe912ede.gif)
_bug reproduction: when you click to see the second image, you still see the first image rendered and then the new image is displayed.

![bugfix](https://user-images.githubusercontent.com/707019/53494239-083bc000-3a7c-11e9-81c8-01b1abce9ef7.gif)
_bug is fixed and the previous image isn't displayed before the second image is rendered_