### PR TITLE
Fix CC0 text on photo details page

### DIFF
--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -33,7 +33,7 @@
           <li>
             <h3>License</h3>
             <a class="photo_license" :href="ccLicenseURL">
-            CC {{ image.license }} {{ image.license_version }}
+            {{ fullLicenseName }}
             </a>
             <license-icons :image="image"></license-icons>
           </li>
@@ -120,6 +120,12 @@ export default {
 
       return url;
     },
+    fullLicenseName() {
+      const license = this.image.license;
+      const version = this.image.license_version;
+
+      return license === 'cc0' ? `${license} ${version}` : `CC ${license} ${version}`;
+    },
     textAttribution() {
       return () => {
         const image = this.image;
@@ -127,8 +133,7 @@ export default {
         const byCreator = image.creator ? `by ${image.creator}` : ' ';
 
         return `"${image.title}" ${byCreator}
-                is licensed under CC ${image.license.toUpperCase()}
-                ${image.license_version}. To view a copy of this license, visit: ${licenseURL}`;
+                is licensed under ${this.fullLicenseName.toUpperCase()}. To view a copy of this license, visit: ${licenseURL}`;
       };
     },
     HTMLAttribution() {
@@ -140,7 +145,7 @@ export default {
                 ${byCreator}
                 is licensed under
                 <a href="${this.ccLicenseURL}">
-                  CC ${image.license.toUpperCase()} ${image.license_version}
+                  ${this.fullLicenseName.toUpperCase()}
                 </a>`;
       };
     },

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -63,7 +63,7 @@
             </span>
             is licensed under
             <a class="photo_license" :href="ccLicenseURL">
-            CC {{ image.license}} {{ image.license_version }}
+            {{ fullLicenseName }}
             </a>
           </p>
           <CopyButton :toCopy="HTMLAttribution">Copy to HTML</CopyButton>

--- a/test/unit/specs/components/photo-details.spec.js
+++ b/test/unit/specs/components/photo-details.spec.js
@@ -2,23 +2,30 @@ import PhotoDetails from '@/components/PhotoDetails';
 import render from '../../test-utils/render';
 
 describe('PhotoDetails', () => {
-  const props = {
-    image: {
-      id: 0,
-      title: 'foo',
-      provider: 'flickr',
-      url: 'foo.bar',
-      thumbnail: 'http://foo.bar',
-      foreign_landing_url: 'http://foo.bar',
-      license: 'CC-BY',
-      license_version: '1.0',
-      creator: 'John',
-      creator_url: 'http://creator.com',
-    },
-  };
-  const options = {
-    propsData: props,
-  };
+  let options = null;
+  let props = null;
+
+  beforeEach(() => {
+    props = {
+      image: {
+        id: 0,
+        title: 'foo',
+        provider: 'flickr',
+        url: 'foo.bar',
+        thumbnail: 'http://foo.bar',
+        foreign_landing_url: 'http://foo.bar',
+        license: 'BY',
+        license_version: '1.0',
+        creator: 'John',
+        creator_url: 'http://creator.com',
+      },
+    };
+
+    options = {
+      propsData: props,
+    };
+  });
+
   it('should render correct contents', () => {
     const wrapper = render(PhotoDetails, options);
     expect(wrapper.find('.photo_image').element).toBeDefined();
@@ -27,7 +34,30 @@ describe('PhotoDetails', () => {
 
   it('should generate license URL', () => {
     const wrapper = render(PhotoDetails, options);
-    expect(wrapper.vm.ccLicenseURL).toBe('https://creativecommons.org/licenses/CC-BY/1.0');
+    expect(wrapper.vm.ccLicenseURL).toBe('https://creativecommons.org/licenses/BY/1.0');
+  });
+
+  it('should generate CC0 license URL', () => {
+    options.propsData.image.license = 'cc0';
+    const wrapper = render(PhotoDetails, options);
+    expect(wrapper.vm.ccLicenseURL).toBe('https://creativecommons.org/publicdomain/zero/1.0/');
+  });
+
+  it('should generate CC PDM license URL', () => {
+    options.propsData.image.license = 'pdm';
+    const wrapper = render(PhotoDetails, options);
+    expect(wrapper.vm.ccLicenseURL).toBe('https://creativecommons.org/publicdomain/mark/1.0/');
+  });
+
+  it('should generate license name', () => {
+    const wrapper = render(PhotoDetails, options);
+    expect(wrapper.vm.fullLicenseName).toBe('CC BY 1.0');
+  });
+
+  it('should generate CC-0 license name', () => {
+    options.propsData.image.license = 'cc0';
+    const wrapper = render(PhotoDetails, options);
+    expect(wrapper.vm.fullLicenseName).toBe('cc0 1.0');
   });
 
   it('should generate text attribution', () => {


### PR DESCRIPTION
Renders "CC0 1.0" instead of "CC CC0 1.0"

Fixes #194 

![screen shot 2019-02-27 at 12 39 34](https://user-images.githubusercontent.com/707019/53502413-c1a29180-3a8c-11e9-9a74-aed71ec8a894.png)
