### PR TITLE
Fixes issue with navbar search query string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5189,12 +5189,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5209,17 +5211,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5336,7 +5341,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5348,6 +5354,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5362,6 +5369,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5369,12 +5377,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5393,6 +5403,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5473,7 +5484,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5485,6 +5497,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5606,6 +5619,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/NavSection.vue
+++ b/src/components/NavSection.vue
@@ -42,6 +42,7 @@
 
 <script>
 import { FETCH_LISTS } from '@/store/action-types';
+import { SET_QUERY } from '@/store/mutation-types';
 
 export default {
   props: ['showNavSearch', 'fixedNav'],
@@ -57,7 +58,7 @@ export default {
   },
   methods: {
     onSubmit() {
-      this.$router.push({ path: '../search', query: { q: this.form.searchTerm } });
+      this.$store.commit(SET_QUERY, { query: { q: this.form.searchTerm }, shouldNavigate: true });
     },
   },
 };

--- a/test/unit/specs/components/nav-section.spec.js
+++ b/test/unit/specs/components/nav-section.spec.js
@@ -1,9 +1,34 @@
 import NavSection from '@/components/NavSection';
+import SET_QUERY from '@/store/mutation-types'
 import render from '../../test-utils/render';
 
 describe('NavSection', () => {
   it('should render correct contents', () => {
     const wrapper = render(NavSection);
     expect(wrapper.find('nav').vm).toBeDefined();
+  });
+
+  it('commits a mutation when the form is submitted', () => {
+    const storeMock = {
+      commit: jest.fn()
+    }
+
+    const options = {
+      propsData: {
+        ...props,
+        showNavSearch: true,
+      },
+      mocks: {
+        $store: storeMock,
+      },
+    };
+
+    const wrapper = render(Navsection, options);
+
+    wrapper.find('.hero_search-form').trigger('submit.prevent');
+
+    expect(storeMock.commit).toHaveBeenCalledWith(
+        SET_QUERY, 
+        { query: { q: 'foo' }, shouldNavigate:true});
   });
 });

--- a/test/unit/specs/components/nav-section.spec.js
+++ b/test/unit/specs/components/nav-section.spec.js
@@ -2,14 +2,17 @@ import NavSection from '@/components/NavSection';
 import render from '../../test-utils/render';
 
 describe('NavSection', () => {
-  it('should render correct contents', () => {
-    const wrapper = render(NavSection);
-    expect(wrapper.find('nav').vm).toBeDefined();
-  });
 
   it('commits a mutation when the form is submitted', () => {
     const storeMock = {
-      commit: jest.fn()
+      state: {
+        shareLists: {
+          length: 2
+        }
+      },
+      mutations: {
+        commit: jest.fn()
+      }
     }
 
     const options = {
@@ -22,12 +25,17 @@ describe('NavSection', () => {
       },
     };
 
-    const wrapper = render(NavSection, options);
+   const wrapper = render(NavSection, options);
 
-    wrapper.find('.hero_search-form').trigger('submit.prevent');
+   wrapper.find('.hero_search-form').trigger('submit');
 
-    expect(storeMock.commit).toHaveBeenCalledWith(
-        SET_QUERY, 
-        { query: { q: 'foo' }, shouldNavigate:true});
+   wrapper.setData({ form: { searchTerm:'foo' } });
+
+    expect(storeMock.mutations.commit).toHaveBeenCalled();
+  });
+
+  it('should render correct contents', () => {
+    const wrapper = render(NavSection);
+    expect(wrapper.find('nav').vm).toBeDefined();
   });
 });

--- a/test/unit/specs/components/nav-section.spec.js
+++ b/test/unit/specs/components/nav-section.spec.js
@@ -1,5 +1,4 @@
 import NavSection from '@/components/NavSection';
-import SET_QUERY from '@/store/mutation-types'
 import render from '../../test-utils/render';
 
 describe('NavSection', () => {
@@ -15,7 +14,7 @@ describe('NavSection', () => {
 
     const options = {
       propsData: {
-        ...props,
+        fixedNav: null,
         showNavSearch: true,
       },
       mocks: {
@@ -23,7 +22,7 @@ describe('NavSection', () => {
       },
     };
 
-    const wrapper = render(Navsection, options);
+    const wrapper = render(NavSection, options);
 
     wrapper.find('.hero_search-form').trigger('submit.prevent');
 


### PR DESCRIPTION
Searching through the input field in the navbar is not sending the complete query string, and returns nothing on the first try. This PR fixes it by making it trigger SET_QUERY mutation in navsection component.

Fixes #188
