### PR TITLE
Fix encoding on Photo Details page

### DIFF
--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -151,6 +151,24 @@ export default {
     },
   },
   methods: {
+    decode(data) {
+      if (data) {
+        const r = /\\x([\d\w]{2})/gi;
+        const x = data.replace(r, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
+        const res = decodeURI(x);
+        return res;
+      }
+      return '';
+    },
+    decodeURL(data) {
+      if (data) {
+        const r = /\\u([\d\w]{4})/gi;
+        const x = data.replace(r, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
+        const res = decodeURI(x);
+        return res;
+      }
+      return '';
+    },
     onGoBackToSearchResults() {
       this.$router.push({ name: 'browse-page', query: this.query });
     },
@@ -163,6 +181,21 @@ export default {
       imageWithDimensions.pageY = event.pageY;
 
       this.$store.commit(SELECT_IMAGE_FOR_LIST, { image: imageWithDimensions });
+    },
+  },
+  watch: {
+    image() {
+      const decode = this.decode;
+      const image = this.image;
+      const decodeURL = this.decodeURL;
+      image.creator = decode(image.creator);
+      image.title = decode(image.title);
+      image.license = decode(image.license);
+      image.license_version = decode(image.license_version);
+      image.provider = decode(image.provider);
+      image.creator_url = decodeURL(image.creator_url);
+      image.foreign_landing_url = decodeURL(image.foreign_landing_url);
+      image.url = decodeURL(image.url);
     },
   },
 };

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -153,7 +153,7 @@ export default {
   },
   methods: {
     onGoBackToSearchResults() {
-       this.$router.push({ name: 'browse-page', query: this.query });
+      this.$router.push({ name: 'browse-page', query: this.query });
     },
     onImageLoad(event) {
       this.$emit('onImageLoaded', event);

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -88,6 +88,7 @@
 import CopyButton from '@/components/CopyButton';
 import LicenseIcons from '@/components/LicenseIcons';
 import { SELECT_IMAGE_FOR_LIST } from '@/store/mutation-types';
+import decodeData from '@/utils/decodeData';
 
 export default {
   name: 'photo-details',
@@ -151,26 +152,8 @@ export default {
     },
   },
   methods: {
-    decode(data) {
-      if (data) {
-        const r = /\\x([\d\w]{2})/gi;
-        const x = data.replace(r, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
-        const res = decodeURI(x);
-        return res;
-      }
-      return '';
-    },
-    decodeURL(data) {
-      if (data) {
-        const r = /\\u([\d\w]{4})/gi;
-        const x = data.replace(r, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
-        const res = decodeURI(x);
-        return res;
-      }
-      return '';
-    },
     onGoBackToSearchResults() {
-      this.$router.push({ name: 'browse-page', query: this.query });
+       this.$router.push({ name: 'browse-page', query: this.query });
     },
     onImageLoad(event) {
       this.$emit('onImageLoaded', event);
@@ -185,17 +168,9 @@ export default {
   },
   watch: {
     image() {
-      const decode = this.decode;
       const image = this.image;
-      const decodeURL = this.decodeURL;
-      image.creator = decode(image.creator);
-      image.title = decode(image.title);
-      image.license = decode(image.license);
-      image.license_version = decode(image.license_version);
-      image.provider = decode(image.provider);
-      image.creator_url = decodeURL(image.creator_url);
-      image.foreign_landing_url = decodeURL(image.foreign_landing_url);
-      image.url = decodeURL(image.url);
+      image.creator = decodeData(image.creator);
+      image.title = decodeData(image.title);
     },
   },
 };

--- a/src/utils/decodeData.js
+++ b/src/utils/decodeData.js
@@ -1,8 +1,10 @@
 export default function decodeData(data) {
   if (data) {
-    const regex = /\\x([\d\w]{2})/gi;
-    const temp = data.replace(regex, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
-    const res = decodeURI(temp);
+    const regexASCII = /\\x([\d\w]{2})/gi;
+    const ascii = data.replace(regexASCII, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
+    const regexUni = /\\u([\d\w]{4})/gi;
+    const uni = ascii.replace(regexUni, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
+    const res = decodeURI(uni);
     return res;
   }
   return '';

--- a/src/utils/decodeData.js
+++ b/src/utils/decodeData.js
@@ -1,0 +1,9 @@
+export default function decodeData(data) {
+  if (data) {
+    const regex = /\\x([\d\w]{2})/gi;
+    const temp = data.replace(regex, (match, grp) => String.fromCharCode(parseInt(grp, 16)));
+    const res = decodeURI(temp);
+    return res;
+  }
+  return '';
+}

--- a/test/unit/specs/utils/decodeData.spec.js
+++ b/test/unit/specs/utils/decodeData.spec.js
@@ -14,9 +14,21 @@ describe('decodeData', () => {
     expect(decodeData(data)).toEqual(""); 
   });
 
-  it('decodes unicode strings', () => {
+  it('returns decoded ASCII hexacode strings', () => {
     const data = 's\\xe9'
 
     expect(decodeData(data)).toBe('s\xe9');
   });
+
+  it('returns decoded unicode strings', () => {
+    const data = 's\\u1234'
+
+    expect(decodeData(data)).toBe('s\u1234');
+  });
+
+  it('returns decoded strings consisting of both unicode and ASCII hexacode characters', () => {
+    const data = 's\\u1234\xe9'
+
+    expect(decodeData(data)).toBe('s\u1234\xe9');
+  });  
 });

--- a/test/unit/specs/utils/decodeData.spec.js
+++ b/test/unit/specs/utils/decodeData.spec.js
@@ -1,0 +1,22 @@
+import decodeData from '@/utils/decodeData';
+
+describe('decodeData', () => {
+  it('returns empty string for empty string', () => {
+    const data = "";
+
+    expect(decodeData(data)).toEqual("");
+  });
+
+  it('returns empty string for undefined data', () => {
+    const data = undefined;
+    const empty="";
+
+    expect(decodeData(data)).toEqual(""); 
+  });
+
+  it('decodes unicode strings', () => {
+    const data = 's\\xe9'
+
+    expect(decodeData(data)).toBe('s\xe9');
+  });
+});


### PR DESCRIPTION
-> Decodes the data encoded in the API results on the front-end.
-> Renders "Léontine Walter" instead of "L\xe9ontine Walter". 
-> Problem Detected:- The characters in data returned by API are double escaped.

Fixes #192, #181, #154 and #107 

![screenshot 54](https://user-images.githubusercontent.com/33460761/53664897-eca90300-3c8f-11e9-95d8-55ec33b9c2e1.png)
