### PR TITLE
strip whitespace from queries

### DIFF
--- a/src/utils/prepareSearchQueryParams.js
+++ b/src/utils/prepareSearchQueryParams.js
@@ -3,6 +3,10 @@ export default function prepareSearchQueryParams(searchParams) {
     ...searchParams,
   };
 
+  if (params.q && params.q.length > 0) {
+    params.q = params.q.trim();
+  }
+
   if (params.searchBy && params.searchBy.length > 0) {
     params[params.searchBy] = params.q;
     delete params.q;

--- a/test/unit/specs/utils/prepareSearchQueryParams.spec.js
+++ b/test/unit/specs/utils/prepareSearchQueryParams.spec.js
@@ -42,4 +42,14 @@ describe('prepareSearchQueryParams', () => {
     const result = prepareSearchQueryParams(params);
     expect(result.q).toBe('foo');
   });
+
+  it('removes leading and trailing whitespace from "q" key', () => {
+    const params = {
+      q: ' foo ',
+    };
+
+    const result = prepareSearchQueryParams(params);
+    expect(result.q).toBe('foo');
+  });
+
 });


### PR DESCRIPTION
Removes leading and trailing whitespace from the "q" key of search params

Fixes #170 
