### PR TITLE
Add option to 'Copy Rich text' in attributions

### DIFF
--- a/src/analytics/events.js
+++ b/src/analytics/events.js
@@ -7,3 +7,7 @@ export function CopyTextAttribution(text) {
 export function CopyHtmlAttribution(text) {
   return new Event('Attribution', 'Copy HTML', text);
 }
+
+export function CopyRtfAttribution(text) {
+  return new Event('Attribution', 'Copy RTF', text);
+}

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -7,12 +7,10 @@
 </template>
 
 <script>
-import Clipboard from 'clipboard';
 import { COPY_ATTRIBUTION } from '@/store/action-types';
 
 export default {
   data: () => ({
-    clipboard: null,
     success: false,
   }),
   props: {
@@ -23,34 +21,55 @@ export default {
       required: true,
     },
   },
-  mounted() {
-    this.clipboard = new Clipboard(this.$el, {
-      text: () => this.toCopy().replace(/\s\s/g, ''),
-    });
+  methods: {
+    listener: function (clickEvent) {
+      // Prepare the content to copy into the clipboard
+      let content = this.toCopy().replace(/\s\s/g, '');
 
-    this.clipboard.on('success', (e) => {
+      // Load the content into the clipboard
+      let copier = (event) => {
+        // If the content type is RTF, paste as rich text into the clipboard
+        if (this.contentType === "rtf") {
+          event.clipboardData.setData("text/html", content);
+        }
+        // Paste as plain text into the clipboard
+        event.clipboardData.setData("text/plain", content);
+        // Prevent the default action
+        event.preventDefault();
+      }
+      document.addEventListener("copy", copier);
+      document.execCommand("copy");
+      document.removeEventListener("copy", copier);
+      
+      // Set the success flag and log the copy action for Analytics
       this.success = true;
       this.$store.dispatch(COPY_ATTRIBUTION, {
         contentType: this.$props.contentType,
-        content: e.text,
+        content: content,
       });
+
+      // Set a timeout for the success flag to be reset
       setTimeout(() => {
         this.success = false;
       }, 2000);
-    });
+
+      // Prevent the default action
+      clickEvent.preventDefault();
+    },
+  },
+  mounted() {
+    this.$el.addEventListener("click", this.listener);
   },
   destroyed() {
-    // unattach our clipboard instance when component is destroyed
-    this.clipboard.destroy();
-    this.clipboard = null;
-  },
+    this.$el.removeEventListener("click", this.listener);
+  }
 };
 </script>
 
 <style scoped>
   .photo_copy-btn {
     border-radius: 3px;
-    width: 49%;
+    width: 32%;
     background: #4a69ca;
   }
 </style>

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -66,8 +66,24 @@
             {{ fullLicenseName }}
             </a>
           </p>
-          <CopyButton :toCopy="HTMLAttribution" contentType="html">Copy to HTML</CopyButton>
-          <CopyButton :toCopy="textAttribution" contentType="text">Copy to Text</CopyButton>
+          <h3>
+            Copy
+          </h3>
+          <CopyButton :toCopy="HTMLAttribution"
+                      contentType="html"
+                      title="Can be used in website code">
+            HTML code
+          </CopyButton>
+          <CopyButton :toCopy="textAttribution"
+                      contentType="text"
+                      title="Can be used in static documents">
+            Plain text
+          </CopyButton>
+          <CopyButton :toCopy="HTMLAttribution"
+                      contentType="rtf"
+                      title="Can be used in WYSIWYG editors">
+            Rich text
+          </CopyButton>
         </section>
         <section class="photo_usage">
           <header class="photo_info-header">

--- a/src/store/attribution-store.js
+++ b/src/store/attribution-store.js
@@ -1,4 +1,8 @@
-import { CopyTextAttribution, CopyHtmlAttribution } from '@/analytics/events';
+import { 
+  CopyRtfAttribution,
+  CopyTextAttribution, 
+  CopyHtmlAttribution, 
+} from '@/analytics/events';
 import {
   COPY_ATTRIBUTION,
 } from './action-types';
@@ -6,10 +10,18 @@ import {
 const actions = GoogleAnalytics => ({
   // eslint-disable-next-line no-unused-vars
   [COPY_ATTRIBUTION]({ commit }, params) {
-    const event = params.contentType === 'html' ?
-      new CopyHtmlAttribution(params.content) :
-      new CopyTextAttribution(params.content);
-
+    let event;
+    switch(params.contentType) {
+      case "html":
+        event = new CopyHtmlAttribution(params.content);
+        break;
+      case "rtf":
+        event = new CopyRtfAttribution(params.content);
+        break;
+      default:
+        event = new CopyTextAttribution(params.content);
+        break;
+    }
     GoogleAnalytics.sendEvent(event);
   },
 });


### PR DESCRIPTION
The current attribution copy options are limited to HTML code and plain text. This PR adds a third option, the ability to copy the attribution as rich text that can easily be pasted into any WYSIWYG editor such as **TinyMCE** in Wordpress or any desktop-based text processor such as Google **Docs**, Microsoft **Word** or Apple **Pages**.

This issue addresses a more generalised version of the concerned raised by @janeatcc in #106. As an added advantage, this PR removes the dependency on the `clipboard` npm package, which is always better for page load times. The compatibility of this feature is documented at [MDN](https://developer.mozilla.org/en-US/docs/Web/Events/copy#Browser_compatibility).

This is the screenshot of the new copy system:
![image](https://user-images.githubusercontent.com/16580576/54161034-00feb400-4477-11e9-80d9-923b35c7b895.png)