### PR TITLE
Photo overflowing into tags section on Safari

### DIFF
--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -33,6 +33,7 @@
   text-align: center;
   padding: 30px;
   max-height: 720px;
+  overflow: auto;
 
   img {
     position: relative;


### PR DESCRIPTION

[Short description explaining the high-level reason for the pull request]

In Safari, the photos end up being overflowed into the tags section. This helps prevent it.

Before:
<img width="943" alt="before-image" src="https://user-images.githubusercontent.com/26908305/54176392-0a7f2080-4465-11e9-8148-0efb95226882.png">



After:
<img width="629" alt="after-image" src="https://user-images.githubusercontent.com/26908305/54176403-0eab3e00-4465-11e9-9d15-833188da192a.png">
[Link to existing Issue #]

[If this Pull Request contains any UI changes, provide an image or GIF displaying the changes]