### PR TITLE
Add a check on creator URL and conditionally render anchor tags

### DIFF
--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -24,7 +24,8 @@
           <li>
             <h3>Creator</h3>
             <span v-if="image.creator">
-              <a :href="image.creator_url">{{ image.creator }}</a>
+              <a v-if="image.creator_url" :href="image.creator_url">{{ image.creator }}</a>
+              <span v-else>{{ image.creator }}</span>
             </span>
             <span v-else>
               Not Available
@@ -59,7 +60,8 @@
             <a :href="image.foreign_landing_url">"{{ image.title }}"</a>
             <span v-if="image.creator">
               by
-              <a :href="image.creator_url">{{ image.creator }}</a>
+              <a v-if="image.creator_url" :href="image.creator_url">{{ image.creator }}</a>
+              <span v-else>{{ image.creator }}</span>
             </span>
             is licensed under
             <a class="photo_license" :href="ccLicenseURL">
@@ -140,7 +142,17 @@ export default {
     HTMLAttribution() {
       return () => {
         const image = this.image;
-        const byCreator = image.creator ? `by <a href="${image.creator_url}">${image.creator}</a>` : ' ';
+
+        let byCreator;
+        if (image.creator) {
+          if (image.creator_url) {
+            byCreator = `by <a href="${image.creator_url}">${image.creator}</a>`;
+          } else {
+            byCreator = `by ${image.creator}`;
+          }
+        } else {
+          byCreator = ' ';
+        }
 
         return `<a href="${image.foreign_landing_url}">"${image.title}"</a>
                 ${byCreator}

--- a/test/unit/specs/components/photo-details.spec.js
+++ b/test/unit/specs/components/photo-details.spec.js
@@ -76,6 +76,22 @@ describe('PhotoDetails', () => {
     expect(wrapper.vm.HTMLAttribution()).toContain(`<a href="${wrapper.vm.ccLicenseURL}">`);
   });
 
+  it('should generate html attribution without creator URL', () => {
+    options.propsData.image.creator_url = null;
+    const wrapper = render(PhotoDetails, options);
+    expect(wrapper.vm.HTMLAttribution()).toContain(`by ${props.image.creator}`);
+    expect(wrapper.vm.HTMLAttribution()).toContain(`<a href="${props.image.foreign_landing_url}">"${props.image.title}"</a>`);
+    expect(wrapper.vm.HTMLAttribution()).toContain(`<a href="${wrapper.vm.ccLicenseURL}">`);
+  });
+
+  it('should generate html attribution without creator URL', () => {
+    options.propsData.image.creator = null;
+    const wrapper = render(PhotoDetails, options);
+    expect(wrapper.vm.HTMLAttribution()).not.toContain('by');
+    expect(wrapper.vm.HTMLAttribution()).toContain(`<a href="${props.image.foreign_landing_url}">"${props.image.title}"</a>`);
+    expect(wrapper.vm.HTMLAttribution()).toContain(`<a href="${wrapper.vm.ccLicenseURL}">`);
+  });
+
   it('renders link back to search results if enabled', () => {
     const wrapper = render(PhotoDetails, {
       propsData: {


### PR DESCRIPTION
CC search displays creators as anchor tags regardless of whether the `creator_url` attribute on `image` is populated or isn't. This PR corrects that by removing the anchor tag in case `creator_url` has a falsy value. This also updates the HTML attribution for such images, by avoiding HTML with `<a href="null">...</a>` situations.

This PR addresses issue #181 raised by @janeatcc.

The screenshot shows the updated appearance of the `PhotoDetails` component.
![image](https://user-images.githubusercontent.com/16580576/54235770-07a13000-4538-11e9-9e43-d7b6969e82b0.png)
