### PR TITLE
Fixed dead contact link

### DIFF
--- a/src/components/FooterSection.vue
+++ b/src/components/FooterSection.vue
@@ -22,7 +22,7 @@
         </div>
         <div class="medium-3 large-3 medium-offset-1 large-offset-1 cell">
           <div class="column footer_contact">
-            <h6><a href="/about/contact">We'd love to hear from you!</a></h6>
+            <h6><a href="https://creativecommons.org/about/contact/">We'd love to hear from you!</a></h6>
               <address>
                 Creative Commons<br>
                 PO Box 1866, Mountain View, CA 94042


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]
* There was a dead relative link to /about/contact, but no such page exists. The contact page is externally located at https://creativecommons.org/about/contact/

[Link to existing Issue #]

[If this Pull Request contains any UI changes, provide an image or GIF displaying the changes]
