### PR TITLE
Ellipsise overflowing titles and show the full title on hover

### DIFF
--- a/src/components/SearchGridCell.vue
+++ b/src/components/SearchGridCell.vue
@@ -11,6 +11,7 @@
         </figcaption>
         <figcaption class="search-grid_item-overlay search-grid_item-overlay__bottom">
           <a class="search-grid_overlay-provider"
+             :title="image.title"
              :href="getImageForeignUrl(image)"
              @click.stop="() => false"
              target="new">
@@ -151,6 +152,9 @@ export default {
     left: 10px;
     z-index: 100;
     color: #fff;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
This is a _very minor_ pull request that truncates long titles with ellipses and adds the full title in the tooltip. This does not fix any open issue on the repository but does address a real-world hiccup.

Before:
![image](https://user-images.githubusercontent.com/16580576/54479914-41c84580-4848-11e9-89b3-1f1a7e027df1.png)
After:
![image](https://user-images.githubusercontent.com/16580576/54479919-59073300-4848-11e9-87c2-e31d04c287ae.png)
