### PR TITLE
Run lint during CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 
 script:
   - npm run unit
+  - npm run lint
 
 node_js:
   - lts/*

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -147,10 +147,12 @@ export default {
         if (image.creator) {
           if (image.creator_url) {
             byCreator = `by <a href="${image.creator_url}">${image.creator}</a>`;
-          } else {
+          }
+          else {
             byCreator = `by ${image.creator}`;
           }
-        } else {
+        }
+        else {
           byCreator = ' ';
         }
 

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -8,7 +8,6 @@ import {
   SET_IMAGE,
   SET_IMAGE_PAGE,
   SET_IMAGES,
-  SET_IS_PAGE_CHANGE,
   SET_QUERY,
   SET_RELATED_IMAGES,
 } from '@/store/mutation-types';

--- a/test/unit/specs/utils/decodeData.spec.js
+++ b/test/unit/specs/utils/decodeData.spec.js
@@ -2,33 +2,32 @@ import decodeData from '@/utils/decodeData';
 
 describe('decodeData', () => {
   it('returns empty string for empty string', () => {
-    const data = "";
+    const data = '';
 
-    expect(decodeData(data)).toEqual("");
+    expect(decodeData(data)).toEqual('');
   });
 
   it('returns empty string for undefined data', () => {
     const data = undefined;
-    const empty="";
 
-    expect(decodeData(data)).toEqual(""); 
+    expect(decodeData(data)).toEqual('');
   });
 
   it('returns decoded ASCII hexacode strings', () => {
-    const data = 's\\xe9'
+    const data = 's\\xe9';
 
     expect(decodeData(data)).toBe('s\xe9');
   });
 
   it('returns decoded unicode strings', () => {
-    const data = 's\\u1234'
+    const data = 's\\u1234';
 
     expect(decodeData(data)).toBe('s\u1234');
   });
 
   it('returns decoded strings consisting of both unicode and ASCII hexacode characters', () => {
-    const data = 's\\u1234\xe9'
+    const data = 's\\u1234\xe9';
 
     expect(decodeData(data)).toBe('s\u1234\xe9');
-  });  
+  });
 });

--- a/test/unit/specs/utils/prepareSearchQueryParams.spec.js
+++ b/test/unit/specs/utils/prepareSearchQueryParams.spec.js
@@ -51,5 +51,4 @@ describe('prepareSearchQueryParams', () => {
     const result = prepareSearchQueryParams(params);
     expect(result.q).toBe('foo');
   });
-
 });


### PR DESCRIPTION
Runs ES Lint during the CI build, so that PRs with lint issues will fail build and not be allowed to be merged

Fixes #240 