### PR TITLE
Update tooltip for CC watermark

### DIFF
--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -173,8 +173,8 @@ export default {
   data: () => ({
     shouldEmbedMetadata: false,
     shouldWatermark: false,
-    watermarkHelp: 'Wrap image in a white frame and include attribution text',
-    metadataHelp: 'Embed attribution in an EXIF metadata attribute in the image file',
+    watermarkHelp: 'This option frames the image in white with a plain text attribution beneath.',
+    metadataHelp: 'This option embeds attribution and CC license metadata in the image file using XMP.',
   }),
   computed: {
     ccLicenseURL() {


### PR DESCRIPTION
Updates the tooltip text for the CC watermark checkboxes

Fixes #256 

<img width="330" alt="Screen Shot 2019-04-03 at 14 59 52" src="https://user-images.githubusercontent.com/707019/55480687-2bc8cc00-5621-11e9-8867-fe3a2953f286.png">

<img width="357" alt="Screen Shot 2019-04-03 at 15 00 00" src="https://user-images.githubusercontent.com/707019/55480693-2d928f80-5621-11e9-8ef6-660a51783169.png">
