### PR TITLE
Fix homepage sections on wide screens

### DIFF
--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -255,10 +255,6 @@ export default {
   @media screen and (max-width: 600px) {
     .search-form_input {
       font-size: 18px;
-      width: 60%;
-    }
-    .search-form_toolbar {
-      width: 40%;
     }
   }
 </style>

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -4,7 +4,7 @@
         @submit.prevent="onSubmit"
         class="search-form">
     <div class="search-form_ctr grid-x global-nav show-for-smedium">
-        <div class="search-form_inner-ctr cell medium-12 large-10">
+        <div class="search-form_inner-ctr cell">
           <input required="required"
                  autofocus="true"
                  class="search-form_input"
@@ -239,14 +239,15 @@ export default {
   }
 
   .search-form_toolbar {
-    width: 400px;
+    flex-wrap: nowrap;
+    flex-direction: row-reverse;
 
     li {
       border-left: 1px solid #E6EAEA;
-      border-right: 1px solid #E6EAEA;
 
-      &:last-of-type {
-        border-left: none;
+      a {
+        width: 80px;
+        text-align: center;
       }
     }
   }
@@ -254,6 +255,10 @@ export default {
   @media screen and (max-width: 600px) {
     .search-form_input {
       font-size: 18px;
+      width: 60%;
+    }
+    .search-form_toolbar {
+      width: 40%;
     }
   }
 </style>

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -3,7 +3,7 @@
         method="post"
         @submit.prevent="onSubmit"
         class="search-form">
-    <div class="search-form_ctr grid-x global-nav show-for-smedium">
+    <div class="search-form_ctr grid-container grid-x global-nav show-for-smedium">
         <div class="search-form_inner-ctr cell">
           <input required="required"
                  autofocus="true"

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -2,7 +2,7 @@
 <div class="home-page grid-container full">
   <header-section showHero="true"></header-section>
   <div class="home-page_body">
-    <section class="featured-images">
+    <section class="featured-images grid-container">
       <header class="featured-images_header">
         <h2 class="featured-items_title">Top Categories</h2>
       </header>
@@ -32,7 +32,7 @@
         </div>
       </div>
     </section>
-  <section class="grid top-images">
+  <section class="top-images grid-container">
     <header class="top-images_header">
       <h2 class="featured-items_title">Top Picks</h2>
     </header>
@@ -204,7 +204,6 @@ $vert-seperate: 4rem;
 }
 
 .featured-images {
-  margin: 30px 0;
   padding: 30px;
 
   &_header {


### PR DESCRIPTION
Fix the homepage sections on wide screens, this PR fixes 2 sections:
- [x] Top Categories (Already mentioned in #245 )
- [x] Top Picks 

## Here's the difference (1850px width screen):
Before:
![Fix homepage sections on wide screens - before](https://user-images.githubusercontent.com/16986422/55815103-11df2b80-5af0-11e9-97d2-126d662d3fd6.png)


After:
![Fix homepage sections on wide screens - after](https://user-images.githubusercontent.com/16986422/55815111-14da1c00-5af0-11e9-8b7e-a795e7aab020.png)
