### PR TITLE
Fix 'Download Image' button animation

### DIFF
--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -260,8 +260,15 @@ export default {
 <style lang="scss" scoped>
   @import '../styles/photodetails.scss';
   .download-watermark {
-    background: #01a635;
+    background: #05A081;
     color: #fff;
+    width: 32%;
+    border-radius: 3px;
+    
+    &:hover {
+      color: #fff;
+      background: #02735d
+    }
   }
 
   label {

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -255,10 +255,6 @@ export default {
   @media screen and (max-width: 600px) {
     .search-form_input {
       font-size: 18px;
-      width: 60%;
-    }
-    .search-form_toolbar {
-      width: 40%;
     }
   }
 </style>

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -4,7 +4,7 @@
         @submit.prevent="onSubmit"
         class="search-form">
     <div class="search-form_ctr grid-x global-nav show-for-smedium">
-        <div class="search-form_inner-ctr cell medium-12 large-10">
+        <div class="search-form_inner-ctr cell">
           <input required="required"
                  autofocus="true"
                  class="search-form_input"
@@ -239,14 +239,15 @@ export default {
   }
 
   .search-form_toolbar {
-    width: 400px;
+    flex-wrap: nowrap;
+    flex-direction: row-reverse;
 
     li {
       border-left: 1px solid #E6EAEA;
-      border-right: 1px solid #E6EAEA;
 
-      &:last-of-type {
-        border-left: none;
+      a {
+        width: 80px;
+        text-align: center;
       }
     }
   }
@@ -254,6 +255,10 @@ export default {
   @media screen and (max-width: 600px) {
     .search-form_input {
       font-size: 18px;
+      width: 60%;
+    }
+    .search-form_toolbar {
+      width: 40%;
     }
   }
 </style>

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -3,7 +3,7 @@
         method="post"
         @submit.prevent="onSubmit"
         class="search-form">
-    <div class="search-form_ctr grid-x global-nav show-for-smedium">
+    <div class="search-form_ctr grid-container grid-x global-nav show-for-smedium">
         <div class="search-form_inner-ctr cell">
           <input required="required"
                  autofocus="true"


### PR DESCRIPTION
Fix the 'Download Image' button animation, mentioned @ #250 !
- [x] Give it the same `width` & `border-radius` as the 'Copy as' buttons
- [x] Use a `dark green` with `white` background

## Here's the difference:
Before (Image by @dhruvkb ):
![](https://user-images.githubusercontent.com/16580576/54917453-db1aea00-4f21-11e9-8305-20693e0e90ae.gif)

After:
![download image button](https://user-images.githubusercontent.com/16986422/55818302-99c83400-5af6-11e9-8855-99ca9a0a095f.gif)
