### PR TITLE
Fix 'Copy Attribution' buttons on safari

### DIFF
--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -23,6 +23,55 @@ export default {
   },
   methods: {
     listener(clickEvent) {
+
+      // Copy To Clipboard [Works on Safari] => Ref: https://stackoverflow.com/a/46858939/5560399
+      window.Clipboard = (function(window, document, navigator) {
+          var textArea,
+              copy;
+
+          function isOS() {
+              return navigator.userAgent.match(/ipad|iphone/i);
+          }
+
+          function createTextArea(text) {
+              textArea = document.createElement('textArea');
+              textArea.value = text;
+              document.body.appendChild(textArea);
+          }
+
+          function selectText() {
+              var range,
+                  selection;
+
+              if (isOS()) {
+                  range = document.createRange();
+                  range.selectNodeContents(textArea);
+                  selection = window.getSelection();
+                  selection.removeAllRanges();
+                  selection.addRange(range);
+                  textArea.setSelectionRange(0, 999999);
+              } else {
+                  textArea.select();
+              }
+          }
+
+          function copyToClipboard() {        
+              document.execCommand('copy');
+              document.body.removeChild(textArea);
+          }
+
+          copy = function(text) {
+              createTextArea(text);
+              selectText();
+              copyToClipboard();
+          };
+
+          return {
+              copy: copy
+          };
+      })(window, document, navigator);
+
+
       // Prepare the content to copy into the clipboard
       const content = this.toCopy().replace(/\s\s/g, '');
 
@@ -38,7 +87,7 @@ export default {
         event.preventDefault();
       };
       document.addEventListener('copy', copier);
-      document.execCommand('copy');
+      Clipboard.copy('text to be copied');
       document.removeEventListener('copy', copier);
 
       // Set the success flag and log the copy action for Analytics

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -255,10 +255,6 @@ export default {
   @media screen and (max-width: 600px) {
     .search-form_input {
       font-size: 18px;
-      width: 60%;
-    }
-    .search-form_toolbar {
-      width: 40%;
     }
   }
 </style>

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -4,7 +4,7 @@
         @submit.prevent="onSubmit"
         class="search-form">
     <div class="search-form_ctr grid-x global-nav show-for-smedium">
-        <div class="search-form_inner-ctr cell medium-12 large-10">
+        <div class="search-form_inner-ctr cell">
           <input required="required"
                  autofocus="true"
                  class="search-form_input"
@@ -239,14 +239,15 @@ export default {
   }
 
   .search-form_toolbar {
-    width: 400px;
+    flex-wrap: nowrap;
+    flex-direction: row-reverse;
 
     li {
       border-left: 1px solid #E6EAEA;
-      border-right: 1px solid #E6EAEA;
 
-      &:last-of-type {
-        border-left: none;
+      a {
+        width: 80px;
+        text-align: center;
       }
     }
   }
@@ -254,6 +255,10 @@ export default {
   @media screen and (max-width: 600px) {
     .search-form_input {
       font-size: 18px;
+      width: 60%;
+    }
+    .search-form_toolbar {
+      width: 40%;
     }
   }
 </style>

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -3,7 +3,7 @@
         method="post"
         @submit.prevent="onSubmit"
         class="search-form">
-    <div class="search-form_ctr grid-x global-nav show-for-smedium">
+    <div class="search-form_ctr grid-container grid-x global-nav show-for-smedium">
         <div class="search-form_inner-ctr cell">
           <input required="required"
                  autofocus="true"


### PR DESCRIPTION
As mentioned in #277 by @janeatcc that `Copy Attribution` buttons aren't working properly on `Safari`.
The problem was using the `document.execCommand("copy")` API and it isn't supported in `Safari`.

I tried to find a working solution for it, and I've attached a reference to it.
