### PR TITLE
Replace Travis with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2.1  # This is the lowest version that supports Orbs
+
+orbs:
+  node: circleci/node@1.0.1  # Use node elements in existing workflows and jobs
+
+jobs:
+  lint:
+    docker:
+    - image: node:8.12.0-alpine
+    steps:
+    - checkout
+    - run: npm install
+    - run: npm run lint
+  
+  unit:
+    docker:
+    - image: node:8.12.0-alpine
+    steps:
+    - checkout
+    - run: npm install
+    - run: npm run unit
+
+workflows:
+  version: 2
+
+  test:
+    jobs:
+    - lint
+    - unit


### PR DESCRIPTION
_Per the decision in a previous engineering meeting_, this PR replaces the Travis configuration file with the CircleCI configuration file, addressing issue #283 opened by @kgodey.

The tests being run are kept as close to the original Travis configuration as possible, while using the `docker` engine running the same Node version as the `Dockerfile`. One important difference is that lint and unit tests are run in parallel unlike in Travis.

**All that remains is to import the project into CircleCI and integrate with GitHub, which I presume I do not have permission to do so I'll defer to @kgodey or @brenoferreira.**

This is how the tests look in the CircleCI interface.
![image](https://user-images.githubusercontent.com/16580576/56386455-6a749e00-623f-11e9-9caa-813acba555fa.png)

<details>
<summary>
Developer Certificate of Origin Version 1.1
</summary>
<p>
Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
<p>
</details>