### PR TITLE
Remove all occurrences of 500px in the codebase

### DIFF
--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -10,11 +10,6 @@ const ImageProviderService = {
   },
   getProviderInfo(providerName) {
     const PROVIDER_NAME_LOOKUP = {
-      '500px': {
-        name: '500px',
-        url: 'https://500px.com',
-        logo: '500px_logo.png',
-      },
       animaldiversity: {
         name: 'Animal Diversity Web',
         url: 'https://animaldiversity.org',

--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -146,7 +146,6 @@ export default {
   data: () => (
     { providers:
       [
-        { code: '500px', name: '500px' },
         { code: 'animaldiversity', name: 'Animal Diversity Web' },
         { code: 'behance', name: 'Behance' },
         { code: 'brooklynmuseum', name: 'Brooklyn Museum' },

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -31,7 +31,7 @@ describe('Search Store', () => {
     });
 
     it('gets query from search params', () => {
-      const state = store.state('?q=landscapes&provider=500px&li=by&lt=all&searchBy=creator');
+      const state = store.state('?q=landscapes&provider=met&li=by&lt=all&searchBy=creator');
       expect(state.imagesCount).toBe(0);
       expect(state.imagePage).toBe(1);
       expect(state.images).toHaveLength(0);
@@ -40,7 +40,7 @@ describe('Search Store', () => {
       expect(state.isFilterVisible).toBeFalsy();
       expect(state.isFilterApplied).toBeTruthy();
       expect(state.query.q).toBe('landscapes');
-      expect(state.query.provider).toBe('500px');
+      expect(state.query.provider).toBe('met');
       expect(state.query.li).toBe('by');
       expect(state.query.lt).toBe('all');
       expect(state.query.searchBy).toBe('creator');
@@ -49,7 +49,7 @@ describe('Search Store', () => {
     });
 
     it('isFilterApplied is set to true when provider filter is set', () => {
-      const state = store.state('?q=landscapes&provider=500px&li=by&lt=');
+      const state = store.state('?q=landscapes&provider=met&li=by&lt=');
       expect(state.isFilterApplied).toBeTruthy();
     });
 

--- a/test/unit/specs/utils/getParameterByName.spec.js
+++ b/test/unit/specs/utils/getParameterByName.spec.js
@@ -19,7 +19,7 @@ describe('getParameterByName', () => {
   });
 
   it('finds "lt"', () => {
-    const query = '?q=landscapes&provider=500px&li=&lt=commercial';
+    const query = '?q=landscapes&provider=met&li=&lt=commercial';
     expect(getParameterByName('lt', query)).toBe('commercial');
   });
 });


### PR DESCRIPTION
This PR resolves issue #293 raised by @janeatcc regarding the removal of all occurrences of 500px from the codebase.

The provider has been removed from the filtering dropdown and from the About page as well. Also if the query parameter is passed as `?provider=500px`, this is the result:
![image](https://user-images.githubusercontent.com/16580576/56420805-16a89a00-62bd-11e9-95bf-8ed8552d9c78.png)

<details>
<summary>
Developer Certificate of Origin Version 1.1
</summary>
<p>
Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
</p>
</details>