### PR TITLE
Change order of filters

### DIFF
--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -2,21 +2,6 @@
   <div :class="{ 'search-filters': true,
                  'search-filters__visible': isFilterVisible, }">
     <div class="grid-x">
-      <div class="filter-option search-filters_providers">
-        <multiselect
-          v-model="filter.provider"
-          @input="onUpdateFilter"
-          tag-placeholder="Add this as new tag"
-          placeholder="All Providers"
-          label="name"
-          track-by="code"
-          :options="providers"
-          :multiple="true"
-          :searchable="true"
-          :closeOnSelect="false"
-          :showLabels="false">
-        </multiselect>
-      </div>
       <div class="filter-option search-filters_license-types">
         <multiselect
           v-model="filter.lt"
@@ -45,6 +30,21 @@
           :options="licenses"
           :multiple="true"
           :searchable="false"
+          :closeOnSelect="false"
+          :showLabels="false">
+        </multiselect>
+      </div>
+      <div class="filter-option search-filters_providers">
+        <multiselect
+          v-model="filter.provider"
+          @input="onUpdateFilter"
+          tag-placeholder="Add this as new tag"
+          placeholder="All Providers"
+          label="name"
+          track-by="code"
+          :options="providers"
+          :multiple="true"
+          :searchable="true"
           :closeOnSelect="false"
           :showLabels="false">
         </multiselect>


### PR DESCRIPTION
Change the `filters` order as requested @ #296 

The new order: _(Left to right)_
- All License types _(Fixed @ #320 , but I don't know what's the best way to merge them together. So, I kept them separately - Please advise here!)_
- All Licenses
- All Providers
- Search by Creator