### PR TITLE
Remove NYPL from providers list

### DIFF
--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -80,11 +80,6 @@ const ImageProviderService = {
         url: 'http://www.nhm.ac.uk/',
         logo: 'nhm_logo.png',
       },
-      nypl: {
-        name: 'New York Public Library',
-        url: 'https://www.nypl.org',
-        logo: 'nypl_logo.svg',
-      },
       rijksmuseum: {
         name: 'Rijksmuseum NL',
         url: 'https://www.rijksmuseum.nl/en/',

--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -160,7 +160,6 @@ export default {
         { code: 'met', name: 'Metropolitan Museum of Art' },
         { code: 'museumsvictoria', name: 'Museums Victoria' },
         { code: 'nhl', name: 'London Natural History Museum' },
-        { code: 'nypl', name: 'New York Public Library' },
         { code: 'rijksmuseum', name: 'Rijksmuseum NL' },
         { code: 'sciencemuseum', name: 'Science Museum – UK' },
         { code: 'thingiverse', name: 'Thingiverse' },


### PR DESCRIPTION
Fixes #312 

Removes NYPL provider from filters list and about page

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
