### PR TITLE
Reuse survey

### DIFF
--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -54,6 +54,7 @@ export default {
 <style scoped>
   .photo_copy-btn {
     width: 10rem;
-    vertical-align: baseline;
+    display: block;
+    margin-top: 1rem;
   }
 </style>

--- a/src/components/HeaderSection.vue
+++ b/src/components/HeaderSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <header :class="header">
+  <header class="header">
     <nav-section :showNavSearch="showNavSearch"></nav-section>
      <slot></slot>
   </header>
@@ -21,24 +21,11 @@ export default {
 <style lang="scss">
   @import '../../node_modules/foundation-sites/scss/foundation';
 
-  @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; position: fixed; }
-  }
-
   .header {
     position: relative;
     z-index: 200;
     width: 100%;
     max-width: 100%;
-
-    &__fixed {
-      position: fixed;
-      top: 0;
-      left: 0;
-      animation-duration: .3s;
-      animation-name: fadeIn;
-    }
   }
 
   .header nav {

--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -28,7 +28,7 @@
         </CopyButton>
       </div>
       <div class="embed-attribution">
-        <span>Copy the HTML below to embed the attribution in your website</span>
+        <span>Copy the HTML below to embed the attribution in your web page</span>
         <textarea id="attribution-html"
                   :value="attributionHtml"
                   cols="30" rows="4"
@@ -38,10 +38,11 @@
                     el="#attribution-html"
                     title="Copy the HTML to embed the attribution in your web page"
                     @copied="onEmbedAttribution">
-          Embed Attribution
+          Copy HTML
         </CopyButton>
       </div>
-    <legal-disclaimer :source="image.provider" :sourceURL="image.foreign_landing_url" />
+      <reuse-survey />
+      <legal-disclaimer :source="image.provider" :sourceURL="image.foreign_landing_url" />
     </div>
   </section>
 </template>
@@ -50,6 +51,7 @@
 import LicenseIcons from '@/components/LicenseIcons';
 import CopyButton from '@/components/CopyButton';
 import LegalDisclaimer from '@/components/LegalDisclaimer';
+import ReuseSurvey from '@/components/ReuseSurvey';
 import { COPY_ATTRIBUTION, EMBED_ATTRIBUTION } from '@/store/action-types';
 
 export default {
@@ -59,6 +61,7 @@ export default {
     LicenseIcons,
     CopyButton,
     LegalDisclaimer,
+    ReuseSurvey,
   },
   methods: {
     onCopyAttribution(e) {

--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -29,16 +29,18 @@
         </CopyButton>
       </div>
       <div class="embed-attribution">
-        <span>Copy the HTML below to embed the attribution with license icons in your web page</span>
+        <span>
+          Copy the HTML below to embed the attribution with license icons in your web page
+        </span>
         <textarea id="attribution-html"
                   :value="attributionHtml"
                   cols="30" rows="4"
                   readonly="readonly">
         </textarea>
         <CopyButton id="embed-attribution-btn"
-                    el="#attribution-html"
-                    title="Copy the HTML to embed the attribution with license icons in your web page"
-                    @copied="onEmbedAttribution">
+                  el="#attribution-html"
+                  title="Copy the HTML to embed the attribution with license icons in your web page"
+                  @copied="onEmbedAttribution">
           Copy HTML
         </CopyButton>
       </div>

--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -1,9 +1,6 @@
 <template>
   <section class="sidebar_section">
-    <!-- TODO: add margin between CC icons and attribution (in the page and in html embed) -->
-    <!-- TODO: move copy rich text button to below the attribution text) -->
     <!-- TODO: try to centralize contents in photo details page) -->
-    <!-- TODO: check https://github.com/creativecommons/cccatalog-frontend/issues/338 -->
     <header class="sidebar_section-header">
       <h2>
         Image Attribution
@@ -32,7 +29,7 @@
         </CopyButton>
       </div>
       <div class="embed-attribution">
-        <span>Copy the HTML below to embed the attribution in your web page</span>
+        <span>Copy the HTML below to embed the attribution with license icons in your web page</span>
         <textarea id="attribution-html"
                   :value="attributionHtml"
                   cols="30" rows="4"
@@ -40,7 +37,7 @@
         </textarea>
         <CopyButton id="embed-attribution-btn"
                     el="#attribution-html"
-                    title="Copy the HTML to embed the attribution in your web page"
+                    title="Copy the HTML to embed the attribution with license icons in your web page"
                     @copied="onEmbedAttribution">
           Copy HTML
         </CopyButton>

--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -16,7 +16,7 @@
             <span v-else>{{ image.creator }}</span>
           </span>
           is licensed under
-          <a class="photo_license" :href="ccLicenseURL">
+          <a class="photo_license" :href="licenseURL">
           {{ fullLicenseName.toUpperCase() }}
           </a>
           <license-icons :image="image"></license-icons>
@@ -65,6 +65,11 @@ export default {
     CopyButton,
     LegalDisclaimer,
     ReuseSurvey,
+  },
+  computed: {
+    licenseURL() {
+      return `${this.ccLicenseURL}&atype=rich`;
+    },
   },
   methods: {
     onCopyAttribution(e) {

--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -1,5 +1,9 @@
 <template>
   <section class="sidebar_section">
+    <!-- TODO: add margin between CC icons and attribution (in the page and in html embed) -->
+    <!-- TODO: move copy rich text button to below the attribution text) -->
+    <!-- TODO: try to centralize contents in photo details page) -->
+    <!-- TODO: check https://github.com/creativecommons/cccatalog-frontend/issues/338 -->
     <header class="sidebar_section-header">
       <h2>
         Image Attribution
@@ -24,7 +28,7 @@
                     el="#attribution"
                     title="Copy the attribution to paste into your blog or document"
                     @copied="onCopyAttribution">
-          Copy
+          Copy rich text
         </CopyButton>
       </div>
       <div class="embed-attribution">

--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <a :href="sourceURL">Verify at source - {{ source }}</a>
+    <a :href="sourceURL">Verify at the source: {{ source }}</a>
     <p class="legal-disclaimer">
       CC Search aggregates data from publicly available repositories of open content.
       CC does not host the content and does not verify that the content is properly CC-licensed

--- a/src/components/PhotoDetails.vue
+++ b/src/components/PhotoDetails.vue
@@ -120,7 +120,8 @@ export default {
       this.activeTab = tabIdx;
     },
     attributionHtml() {
-      return attributionHtml(this.image, this.ccLicenseURL, this.fullLicenseName);
+      const licenseURL = `${this.ccLicenseURL}&atype=html`;
+      return attributionHtml(this.image, licenseURL, this.fullLicenseName);
     },
   },
   watch: {

--- a/src/components/ReuseSurvey.vue
+++ b/src/components/ReuseSurvey.vue
@@ -1,11 +1,10 @@
 <template>
   <div class="reuse-survey">
     <span>How are you using this image?</span>
-    <span>If you intend to use this image, you can answer</span>
+    <span>Let us know how you use this image in</span>
     <a href="https://docs.google.com/forms/d/e/1FAIpQLSeSApxNMup8Ujt-8Vjv53ngltzhJeaHspMykHCD8VKQ39yXAA/viewform">
-      this quick survey here
+      this quick survey
     </a>
-    <span>to let us know how you are using it.</span>
   </div>
 </template>
 

--- a/src/components/ReuseSurvey.vue
+++ b/src/components/ReuseSurvey.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="reuse-survey">
+    <span>How are you using this image?</span>
+    <span>If you intend to use this image, you can answer</span>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeSApxNMup8Ujt-8Vjv53ngltzhJeaHspMykHCD8VKQ39yXAA/viewform">
+      this quick survey here
+    </a>
+    <span>to let us know how you are using it.</span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'reuse-survey',
+};
+</script>
+
+<style lang="scss" scoped>
+  @import '../styles/photodetails.scss';
+
+  .reuse-survey {
+    margin: 2rem 0 2rem;
+
+    span:first-child {
+      font-size: 1.1rem;
+      font-weight: 600;
+      display: block;
+    }
+  }
+</style>

--- a/src/pages/PhotoDetailPage.vue
+++ b/src/pages/PhotoDetailPage.vue
@@ -3,21 +3,23 @@
     <div class="cell">
       <header-section showNavSearch="true" fixedNav="true"></header-section>
     </div>
-    <photo-details :image="image"
-                   :breadCrumbURL="breadCrumbURL"
-                   :shouldShowBreadcrumb="shouldShowBreadcrumb"
-                   :query="query"
-                   :imageWidth="imageWidth"
-                   :imageHeight="imageHeight"
-                   :watermarkEnabled="watermarkEnabled"
-                   :socialSharingEnabled="socialSharingEnabled"
-                   @onImageLoaded="onImageLoaded" />
-    <photo-tags :tags="tags" />
-    <related-images :relatedImages="relatedImages"
-                    :imagesCount="imagesCount"
+    <div class="container cell large-11">
+      <photo-details :image="image"
+                    :breadCrumbURL="breadCrumbURL"
+                    :shouldShowBreadcrumb="shouldShowBreadcrumb"
                     :query="query"
-                    :filter="filter"
-                    :isPrimaryImageLoaded="isPrimaryImageLoaded" />
+                    :imageWidth="imageWidth"
+                    :imageHeight="imageHeight"
+                    :watermarkEnabled="watermarkEnabled"
+                    :socialSharingEnabled="socialSharingEnabled"
+                    @onImageLoaded="onImageLoaded" />
+      <photo-tags :tags="tags" />
+      <related-images :relatedImages="relatedImages"
+                      :imagesCount="imagesCount"
+                      :query="query"
+                      :filter="filter"
+                      :isPrimaryImageLoaded="isPrimaryImageLoaded" />
+    </div>
     <footer-section></footer-section>
   </div>
 </template>
@@ -139,5 +141,10 @@ export default PhotoDetailPage;
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style lang="scss" scoped>
-
+  .container {
+    margin-left: 4vw;
+    @media screen and (max-width: 1050px) {
+      margin-left: 0;
+    }
+  }
 </style>

--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -106,10 +106,8 @@
 }
 
 .photo-attribution {
-  font-size: 0.9rem;
   margin-top: 1rem;
   font-style: italic;
-  text-align: left;
 }
 
 .photo_usage-attribution {

--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -28,7 +28,6 @@
   display: block;
   text-align: left;
   font-size: .9em;
-  margin-top: -10px;
 }
 
 .photo_image-ctr {
@@ -58,8 +57,6 @@
     .sidebar_section-header {
       margin-left: 0px;
     }
-
-    padding: 0 15px 15px 15px;
   }
 
   h4 {
@@ -118,7 +115,7 @@
 
 .photo_related-images,
 .photo_tags {
-  margin: 30px;
+  margin-top: 30px;
   border-top: 1px solid #e7e8e9;
   width: 100%;
 
@@ -180,6 +177,11 @@ label {
 
 .tabs {
   border-bottom: none;
+  border-right: none;
+}
+
+.tabs-panel {
+  padding: 1rem 0 1rem 0;
 }
 
 .tabs-content {
@@ -192,11 +194,6 @@ label {
 
 .attribution-buttons {
   margin-top: 8px;
-}
-
-.provider-logo {
-  height: 48px;
-  margin: 6px 0 0px 0;
 }
 
 .button-group {

--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -4,6 +4,7 @@
 
 .photo_license {
   text-transform: uppercase;
+  margin-right: 5px;
 }
 
 .search-grid {
@@ -113,7 +114,6 @@
 .photo_usage-attribution {
   border-left: 1px solid #e7e8e9;;
   padding-left: 10px;
-  padding-bottom: 15px
 }
 
 .photo_related-images,

--- a/src/utils/attributionHtml.js
+++ b/src/utils/attributionHtml.js
@@ -11,7 +11,7 @@ function attributionHtml(image, ccLicenseURL, fullLicenseName) {
   else if (image.creator && !image.creator_url) {
     creator = `<span> by <span>${image.creator}</span></span>`;
   }
-  const licenseLink = ` is licensed under <a href="${ccLicenseURL}">${fullLicenseName.toUpperCase()}</a>`;
+  const licenseLink = ` is licensed under <a href="${ccLicenseURL}" style="margin-right: 5px;">${fullLicenseName.toUpperCase()}</a>`;
 
   let licenseIcons = `<img style="height: inherit;margin-right: 3px;" src="${baseAssetsPath}/cc_icon.svg" />`; // eslint-disable-line global-require, import/no-dynamic-require
   if (image.license) {


### PR DESCRIPTION
Fixes #326 #339 #338 #339 #346 

* Adds the reuse survey link
* Fixes the Verify At Source text
* Changes the attribution/html embed copy button text

<img width="1734" alt="Screen Shot 2019-04-26 at 11 03 28" src="https://user-images.githubusercontent.com/707019/56796517-fc1d7600-6812-11e9-8b71-a04db63c2256.png">

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
