### PR TITLE
Update legal texts

### DIFF
--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -3,10 +3,9 @@
     <a :href="sourceURL">Verify at source - {{ source }}</a>
     <p class="legal-disclaimer">
       CC Search aggregates data from publicly available repositories of open content.
-      CC does not host the content and is not able to determine whether the content was
-      properly placed under a CC license or whether the attribution information about the
-      content is correct. Please follow the link to the source of the content to independently
-      verify before reuse.
+      CC does not host the content and does not verify that the content is properly CC-licensed
+      or that the attribution information is accurate or complete. Please follow the link to the
+      source of the content to independently verify before reuse.
     </p>
   </div>
 </template>

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -4,37 +4,39 @@
   <div class="about-page_body">
     <h1>About CC Search</h1>
       <p class="about-page_lead-paragraph">
-        There is no larger compendium of shared human knowledge and creativity than the Commons,
-         including over 1.4 billion digital works available under CC tools. Despite the tremendous
-         growth of the Commons, and the widespread use of the CC licenses and public domain marks,
-         there is no simple way to maximize use of, and engagement with, all of that content. There
-         is no front door — no tool designed for the general public to facilitate discovery for the
-         purpose of reuse and remix, to simplify the license terms, make attribution easy, or
-         support curation, and crowdsourced metadata.
+        CC Search is a tool that allows openly licensed and public domain works to be discovered
+        and used by everyone. Creative Commons, the nonprofit behind CC Search, is the maker of the
+        <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">CC licenses</a>,
+        used over 1.4 billion times to help creators share knowledge and creativity online.
       </p>
       <p>
-        Creative Commons’ “CC Search” project will develop and release an open online search and
-        re-use tool that will allow high-quality content from the commons to surface in a more
-        seamless and accessible way. Our beta relies on open APIs and the Common Crawl dataset
-        and focuses on photos as its first media type. It is meant to elicit discussion and inform
-        our development as we build out the full set of tools. “CC Search” will enable users to
-        curate, tag, and remix that content. It will go beyond simple search to aggregate results
-        from across the hundreds of public repositories into a single catalog, and also facilitate
-        the use and re-use through tools like curated lists, saved searches, one- or no-click
-        attribution, and provenance.
+        CC Search searches across more than 300 million images from open APIs and the
+        <a href="http://commoncrawl.org/">Common Crawl</a> dataset.
+        It goes beyond simple search to aggregate results across multiple public repositories
+         into a single catalog, and facilitates reuse through features like machine-generated tags
+         and one-click attribution.
       </p>
-      <h2>New Release</h2>
       <p>
-        This release contains several new features, including AI image tags generated from
-        our collaborator, Clarifai. Clarifai is the best-in-class image classification software
-        that provides tagging support and visual recognition. Clarifai’s API was integrated
-        in the process-flow as a means to automatically generate tags for the new and existing
-        images. This means that CC search has machine-generated tags, user-defined tags, and
-        platform-defined tags that were obtained from the web crawl data. Collectively,
-        these will enhance the user’s search experience and improve the quality of the results.
-        Currently, 10.3 million images have their respective Clarifai tags and the outstanding
-        images will be integrated on an ongoing basis. With this addition, we’re not just
-        cataloging the commons, we’re making it better. CC thanks Clarifai for their support.
+        Currently CC Search only searches images, but we plan to add additional media types such as
+        open texts and audio, with the ultimate goal of providing access to all 1.4 billion CC
+        licensed and public domain works on the web. Learn more about CC’s 2019 vision, strategy
+        and roadmap for CC Search <a href="https://creativecommons.org/2019/03/19/cc-search/">here</a>and
+        see what we’re currently working on <a href="https://github.com/orgs/creativecommons/projects/7">here</a>.
+        All of our code is open source
+        (<a href="https://github.com/creativecommons/cccatalog-frontend/">CC Search</a>,
+        <a href="https://github.com/creativecommons/cccatalog-api/">CC Catalog API</a>,
+        <a href="https://github.com/creativecommons/cccatalog/">CC Catalog</a>)
+        and we <a href="https://creativecommons.github.io/contributing-code/">welcome community contribution</a>.
+      </p>
+      <p>
+        Please note that CC does not verify whether the images are properly CC licensed, or whether
+        the attribution and other licensing information we have aggregated is accurate or complete.
+        Please independently verify the licensing status and attribution information before reusing
+        the content. For more details, read the<a href="https://creativecommons.org/terms/">CC Terms of Use</a>.
+      </p>
+      <p>
+        Looking for the old CC Search portal? Visit
+        <a href="https://oldsearch.creativecommons.org">https://oldsearch.creativecommons.org</a>.
       </p>
       <h2>Providers</h2>
       <div class="about-page_provider-stats-ctr">

--- a/src/pages/FeedbackPage.vue
+++ b/src/pages/FeedbackPage.vue
@@ -2,12 +2,15 @@
   <div class="grid-container full">
     <header-section showNavSearch="true"></header-section>
     <div class="feedback-page">
-      <h1>Feedback</h1>
+      <h1 id="feedback">Feedback</h1>
       <p>
         Thank you for using CC Search! We welcome your ideas for improving the tool below.
         To provide regular user feedback, join the
         <a href="https://creativecommons.slack.com/messages/CCS9CF2JE/details/">#cc-usability</a> channel on
         <a href="https://wiki.creativecommons.org/wiki/Slack#How_to_join_Slack">CC Slack</a>.
+      </p>
+      <p>
+        To report a bug, <a href="#report">click here</a>.
       </p>
 
       <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfb_6yq2Md0v6S-XzsyT7p1QVhqr7MWHqInKdyYh4ReaWn4FQ/viewform?embedded=true"
@@ -20,7 +23,7 @@
       </iframe>
 
       <div>
-        <h1>Report a bug</h1>
+        <h1><a id="report"></a>Report a bug</h1>
         <p>
           If you would like to report a bug you are encountering when using the tool, please email
           <a href="mailto:support-search@creativecommons.org">


### PR DESCRIPTION
Fixes #290 #340 #298 

Updates the text on about page, the legal disclaimer on the photo details page, and adds a link to the report a bug in the feedback page

<img width="1642" alt="Screen Shot 2019-04-26 at 16 16 18" src="https://user-images.githubusercontent.com/707019/56814137-ca220900-683e-11e9-94bf-27ee18d61d70.png">

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
