### PR TITLE
Merge license name with license icons

### DIFF
--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -15,9 +15,6 @@
             <span v-else>{{ image.creator }}</span>
           </span>
           is licensed under
-          <a class="photo_license" :href="ccLicenseURL">
-          {{ fullLicenseName.toUpperCase() }}
-          </a>
           <license-icons :image="image"></license-icons>
         </span>
         <CopyButton id="copy-attribution-btn"

--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -51,7 +51,7 @@ import { COPY_ATTRIBUTION, EMBED_ATTRIBUTION } from '@/store/action-types';
 
 export default {
   name: 'image-attribution',
-  props: ['id', 'image', 'ccLicenseURL', 'fullLicenseName', 'attributionHtml'],
+  props: ['id', 'image', 'attributionHtml'],
   components: {
     LicenseIcons,
     CopyButton,

--- a/src/components/ImageInfo.vue
+++ b/src/components/ImageInfo.vue
@@ -47,7 +47,7 @@ import ImageProviderService from '@/api/ImageProviderService';
 
 export default {
   name: 'image-info',
-  props: ['image', 'ccLicenseURL', 'fullLicenseName', 'imageWidth', 'imageHeight'],
+  props: ['image', 'imageWidth', 'imageHeight'],
   components: {
     LicenseIcons,
   },

--- a/src/components/ImageInfo.vue
+++ b/src/components/ImageInfo.vue
@@ -22,9 +22,6 @@
       </li>
       <li>
         <h3>License</h3>
-        <a class="photo_license" :href="ccLicenseURL">
-        {{ fullLicenseName }}
-        </a>
         <license-icons :image="image"></license-icons>
       </li>
       <li>

--- a/src/components/LicenseIcons.vue
+++ b/src/components/LicenseIcons.vue
@@ -4,6 +4,7 @@
      class="photo-license-icons"
      target="_blank"
      rel="noopener noreferrer">
+    <span>{{image.license.toUpperCase()}} {{image.license_version}}</span>
     <img class="photo-license-icon" src="@/assets/cc_icon.svg"><img
           v-for="(license, index) in onGetLicenseIcon(image.license)"
           v-if="license" class="photo-license-icon"


### PR DESCRIPTION
Fixes #345 

It seems that we've been separating the `LicenseName` from the `LicenseIcons` and that caused an overhead in our architecture, and it caused the #345 as we are - unnecessary - working on some data (i.e. `image.license`)

So, I used the `LicenseIcons` Component to store the name of the license, instead of separating it.

**Suggestion**
What about renaming the `LicenseIcons` component to `LicenseInfo`?
