### PR TITLE
Fix 'logo' bug on small screens

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -76,6 +76,8 @@ $hero-height: 75vh;
 
     @media screen and (max-width: 39.9375em) {
       height: 5.5em;
+      margin-top: 4vh;
+      padding: 0.5em;
     }
   }
 
@@ -145,7 +147,7 @@ $hero-height: 75vh;
 
 .old-search-link {
   position: absolute;
-  top: 2rem;
+  top: 1rem;
   right: 2rem;
 
   @media screen and (max-width: 320px) {


### PR DESCRIPTION
Fixes #354 

This PR:
- Fix the `CC Logo` overlapping the text above (Small screens only)
- Add `padding` to the `CC Logo` to look properly (Small screens only)
- Adjust the `.old-search-link` top space (All screens)

Here's the UI Difference:

| Before | After |
| ------- | ----- |
| ![Before](https://user-images.githubusercontent.com/16986422/56939563-58c9ab00-6b09-11e9-9d99-65a82ffa6b2e.png) | ![After](https://user-images.githubusercontent.com/16986422/56939568-5bc49b80-6b09-11e9-800f-04eb398a889b.png) |


---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
