### PR TITLE
Fix typos/whitespace on 'AboutPage'

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -20,7 +20,7 @@
         Currently CC Search only searches images, but we plan to add additional media types such as
         open texts and audio, with the ultimate goal of providing access to all 1.4 billion CC
         licensed and public domain works on the web. Learn more about CC’s 2019 vision, strategy
-        and roadmap for CC Search <a href="https://creativecommons.org/2019/03/19/cc-search/">here</a>and
+        and roadmap for CC Search <a href="https://creativecommons.org/2019/03/19/cc-search/">here</a> and
         see what we’re currently working on <a href="https://github.com/orgs/creativecommons/projects/7">here</a>.
         All of our code is open source
         (<a href="https://github.com/creativecommons/cccatalog-frontend/">CC Search</a>,
@@ -32,7 +32,7 @@
         Please note that CC does not verify whether the images are properly CC licensed, or whether
         the attribution and other licensing information we have aggregated is accurate or complete.
         Please independently verify the licensing status and attribution information before reusing
-        the content. For more details, read the<a href="https://creativecommons.org/terms/">CC Terms of Use</a>.
+        the content. For more details, read the <a href="https://creativecommons.org/terms/">CC Terms of Use</a>.
       </p>
       <p>
         Looking for the old CC Search portal? Visit


### PR DESCRIPTION
Fixes #290 

A follow-up PR to fix the `typo/whitespace` after #344 

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
