### PR TITLE
Fix responsive issues on 'landscape' mode

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -74,7 +74,7 @@ $hero-height: 75vh;
     margin-bottom: 4vh;
     height: 7em;
 
-    @media screen and (max-width: 39.9375em) {
+    @media screen and (max-width: 39.9375em), (max-height: 720px) {
       height: 5.5em;
       margin-top: 4vh;
       padding: 0.5em;

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -78,7 +78,7 @@ $vert-seperate: 4rem;
   position:fixed;
 
   /* Small only */
-  @media screen and (max-width: 39.9375em) {
+  @media screen and (max-width: 39.9375em), (max-height: 720px) {
     position: relative;
   }
 }


### PR DESCRIPTION
Fixes #377 

As @janeatcc reported, we have a responsive problem with `landscape` mode because our `Media Query` is specified according to the `width` only, not the `height`.

Please note: This PR also fixes the `height` responsive problem with the homepage' `logo`.

## Here's the UI difference:
Before:

![](https://user-images.githubusercontent.com/6394777/57164494-23db8380-6da9-11e9-8a39-acb7971a7eca.jpg)

When Scrolling:
![](https://user-images.githubusercontent.com/6394777/57164500-29d16480-6da9-11e9-88b3-5fac3f7482f6.jpg)


After (Android):
![After](https://user-images.githubusercontent.com/16986422/57186565-d31b7600-6ee1-11e9-885f-3594f3202548.png)

When Scrolling (iPhone):
![When Scrolling](https://user-images.githubusercontent.com/16986422/57186568-d878c080-6ee1-11e9-9093-c292fe1f942c.png)


---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
