### PR TITLE
Fix 'search inputs/filters' overlapping on small screens

### DIFF
--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -239,7 +239,7 @@ export default {
   }
 
   .search-form_toolbar {
-    width: 400px;
+    flex-wrap: nowrap;
 
     li {
       border-left: 1px solid #E6EAEA;


### PR DESCRIPTION
Fixes #377 

Stop overlapping the `Search inputs/filters` on small screens by overwriting the default `foundation` flex style rules.

## Here's the UI difference:
Before:
![Before](https://user-images.githubusercontent.com/16986422/57186692-24c50000-6ee4-11e9-9a12-25e15c2114cc.png)

After:
![Search inputs - filters](https://user-images.githubusercontent.com/16986422/57186685-0c54e580-6ee4-11e9-9459-7c01577a9e85.png)

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
