### PR TITLE
Fixes CAPL provider logo

### DIFF
--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -19,7 +19,7 @@ const ImageProviderService = {
       brooklynmuseum: {
         logo: 'brooklyn_museum_logo.png',
       },
-      capl: {
+      CAPL: {
         logo: 'capl_logo.png',
       },
       clevelandmuseum: {

--- a/src/components/MasonrySearchGridCell.vue
+++ b/src/components/MasonrySearchGridCell.vue
@@ -61,10 +61,15 @@ export default {
       return toAbsolutePath(image.foreign_landing_url);
     },
     getProviderLogo(providerName) {
-      const logo = ImageProviderService.getProviderInfo(providerName).logo;
-      const logoUrl = require(`@/assets/${logo}`); // eslint-disable-line global-require, import/no-dynamic-require
+      const provider = ImageProviderService.getProviderInfo(providerName);
+      if (provider) {
+        const logo = provider.logo;
+        const logoUrl = require(`@/assets/${logo}`); // eslint-disable-line global-require, import/no-dynamic-require
 
-      return logoUrl;
+        return logoUrl;
+      }
+
+      return '';
     },
     onGotoDetailPage(event, image) {
       // doesn't use router to redirect to photo details page in case the user

--- a/test/unit/specs/components/masonry-search-grid-cell.spec.js
+++ b/test/unit/specs/components/masonry-search-grid-cell.spec.js
@@ -2,18 +2,39 @@ import MasonrySearchGridCell from '@/components/MasonrySearchGridCell';
 import render from '../../test-utils/render';
 
 describe('SearchGridCell', () => {
+  const props = {
+    image: {
+      id: 0,
+      title: 'foo',
+      provider: 'flickr',
+      url: 'foo.bar',
+      thumbnail: 'foo.bar',
+      foreign_landing_url: 'foreign_foo.bar',
+    },
+  };
+
   it('should render correct contents', () => {
-    const props = {
-      image: {
-        id: 0,
-        title: 'foo',
-        provider: 'flickr',
-        url: 'foo.bar',
-        thumbnail: 'foo.bar',
-        foreign_landing_url: 'foo.bar',
-      },
-    };
     const wrapper = render(MasonrySearchGridCell, { propsData: props });
     expect(wrapper.find('div').find('figure').element).toBeDefined();
+  });
+
+  it('getProviderLogo should return existing logo', () => {
+    const wrapper = render(MasonrySearchGridCell, { propsData: props });
+    expect(wrapper.vm.getProviderLogo('flickr')).not.toBe('');
+  });
+
+  it('getProviderLogo should not return non existing logo', () => {
+    const wrapper = render(MasonrySearchGridCell, { propsData: props });
+    expect(wrapper.vm.getProviderLogo('does not exist')).toBe('');
+  });
+
+  it('getImageUrl returns image url with https://', () => {
+    const wrapper = render(MasonrySearchGridCell, { propsData: props });
+    expect(wrapper.vm.getImageUrl(props.image)).toBe('https://foo.bar');
+  });
+
+  it('getImageForeignUrl returns foreign image url with https://', () => {
+    const wrapper = render(MasonrySearchGridCell, { propsData: props });
+    expect(wrapper.vm.getImageForeignUrl(props.image)).toBe('https://foreign_foo.bar');
   });
 });


### PR DESCRIPTION
Fixes #368 

Fixes a bug on the rendering of the CAPL provider logo and applies a general fix for the search results if the same issue comes up in the future

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
