### PR TITLE
Hides the search results in case the user is performing a new search

### DIFF
--- a/src/store/search-store.js
+++ b/src/store/search-store.js
@@ -37,9 +37,21 @@ const state = (searchParams) => {
   };
 };
 
+/**
+ * hides the search results in case the user is performing a new search.
+ * This prevents results from a previous search from showing while the
+ * new search results are still loading
+ */
+const hideSearchResultsOnNewSearch = (commit, pageNumber) => {
+  if (!pageNumber) {
+    commit(SET_IMAGES, { images: [] });
+  }
+};
+
 const actions = ImageService => ({
   [FETCH_IMAGES]({ commit }, params) {
     commit(FETCH_START_IMAGES);
+    hideSearchResultsOnNewSearch(commit, params.page);
     const queryParams = prepareSearchQueryParams(params);
     return ImageService.search(queryParams)
       .then(({ data }) => {
@@ -63,6 +75,7 @@ const actions = ImageService => ({
   },
   [FETCH_IMAGE]({ commit }, params) {
     commit(FETCH_START_IMAGES);
+    commit(SET_IMAGE, { image: {} });
     return ImageService.getImageDetail(params)
       .then(({ data }) => {
         commit(FETCH_END_IMAGES);

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -218,11 +218,17 @@ describe('Search Store', () => {
   describe('actions', () => {
     const searchData = { results: ['foo'], result_count: 1 };
     const imageDetailData = 'imageDetails';
-    const imageServiceMock = {
-      search: jest.fn(() => Promise.resolve({ data: searchData })),
-      getImageDetail: jest.fn(() => Promise.resolve({ data: imageDetailData })),
-    };
-    const commit = jest.fn();
+    let imageServiceMock = null;
+    let commit = null;
+
+    beforeEach(() => {
+      imageServiceMock = {
+        search: jest.fn(() => Promise.resolve({ data: searchData })),
+        getImageDetail: jest.fn(() => Promise.resolve({ data: imageDetailData })),
+      };
+      commit = jest.fn();
+    });
+
     it('FETCH_IMAGES on success', (done) => {
       const params = { query: { q: 'foo' }, page: 1, shouldPersistImages: false };
       const action = store.actions(imageServiceMock)[FETCH_IMAGES];
@@ -257,11 +263,30 @@ describe('Search Store', () => {
       });
     });
 
+    it('FETCH_IMAGES resets images if page is not defined', (done) => {
+      const params = { query: { q: 'foo' }, page: undefined, shouldPersistImages: false };
+      const action = store.actions(imageServiceMock)[FETCH_IMAGES];
+      action({ commit }, params).then(() => {
+        expect(commit).toBeCalledWith(SET_IMAGES, { images: [] });
+        done();
+      });
+    });
+
+    it('FETCH_IMAGES does not reset images if page is defined', (done) => {
+      const params = { query: { q: 'foo' }, page: 1, shouldPersistImages: false };
+      const action = store.actions(imageServiceMock)[FETCH_IMAGES];
+      action({ commit }, params).then(() => {
+        expect(commit).not.toBeCalledWith(SET_IMAGES, { images: [] });
+        done();
+      });
+    });
+
     it('FETCH_IMAGE on success', (done) => {
       const params = 'foo';
       const action = store.actions(imageServiceMock)[FETCH_IMAGE];
       action({ commit }, params).then(() => {
         expect(commit).toBeCalledWith(FETCH_START_IMAGES);
+        expect(commit).toBeCalledWith(SET_IMAGE, { image: {} });
         expect(commit).toBeCalledWith(FETCH_END_IMAGES);
 
         expect(commit).toBeCalledWith(SET_IMAGE, { image: imageDetailData });


### PR DESCRIPTION
Fixes #358 

![results](https://user-images.githubusercontent.com/707019/57221802-be81cf80-7000-11e9-9ed8-200cebb1fc3f.gif)


---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
