### PR TITLE
fills link to image in survey

### DIFF
--- a/src/components/ReuseSurvey.vue
+++ b/src/components/ReuseSurvey.vue
@@ -2,7 +2,7 @@
   <div class="reuse-survey">
     <span>How are you using this image?</span>
     <span>Let us know how you use this image in</span>
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeSApxNMup8Ujt-8Vjv53ngltzhJeaHspMykHCD8VKQ39yXAA/viewform">
+    <a :href="formLink">
       this quick survey
     </a>
   </div>
@@ -11,6 +11,12 @@
 <script>
 export default {
   name: 'reuse-survey',
+  computed: {
+    formLink() {
+      const location = window.location.href;
+      return `https://docs.google.com/forms/d/e/1FAIpQLSeNTNdcq8_UI1OiWGKwvnA58ydy0HVHsRmSmRUAc_he-CDa0A/viewform?usp=pp_url&entry.1409847454=${location}`;
+    },
+  },
 };
 </script>
 

--- a/src/components/ReuseSurvey.vue
+++ b/src/components/ReuseSurvey.vue
@@ -14,7 +14,7 @@ export default {
   computed: {
     formLink() {
       const location = window.location.href;
-      return `https://docs.google.com/forms/d/e/1FAIpQLSeNTNdcq8_UI1OiWGKwvnA58ydy0HVHsRmSmRUAc_he-CDa0A/viewform?usp=pp_url&entry.1409847454=${location}`;
+      return `https://docs.google.com/forms/d/e/1FAIpQLSeSApxNMup8Ujt-8Vjv53ngltzhJeaHspMykHCD8VKQ39yXAA/viewform?usp=pp_url&entry.1690035721=${location}`;
     },
   },
 };


### PR DESCRIPTION
Fixes #326 

Automatically fills the link to the image on the reuse survey

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
