### PR TITLE
License type filters on home page

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -20,9 +20,7 @@
             <button class="hero_search-btn" title="Search"></button>
           </div>
       </div>
-      <div>
-        <home-license-filter />
-      </div>
+      <home-license-filter />
     </form>
     <div class="description">
         <p>
@@ -128,7 +126,7 @@ $hero-height: 71vh;
     position: absolute;
     top: 0;
     right: 0;
-    height: calc( 100% - 3px );
+    height: 60px;
     width: 60px;
     margin: 2px;
     font-size: 24px;
@@ -160,7 +158,6 @@ $hero-height: 71vh;
 }
 
 .description {
-  margin-top: 2vh;
   font-style: italic;
 }
 

--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -20,6 +20,9 @@
             <button class="hero_search-btn" title="Search"></button>
           </div>
       </div>
+      <div>
+        <home-license-filter />
+      </div>
     </form>
     <div class="description">
         <p>
@@ -51,9 +54,13 @@
 
 <script>
 import { SET_QUERY } from '@/store/mutation-types';
+import HomeLicenseFilter from './HomeLicenseFilter';
 
 export default {
   name: 'hero-section',
+  components: {
+    HomeLicenseFilter,
+  },
   data: () => ({ form: { searchTerm: '' } }),
   methods: {
     onSubmit() {

--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -177,9 +177,8 @@ $hero-height: 71vh;
   bottom: 1rem;
   right: 2rem;
 
-  @media screen and (max-width: 320px) {
-    font-size: 0.9rem;
-    bottom: 0;
+  @media screen and (max-width: 768px) {
+    display: none;
   }
 }
 

--- a/src/components/HomeLicenseFilter.vue
+++ b/src/components/HomeLicenseFilter.vue
@@ -21,6 +21,7 @@ export default {
     onFilterChanged(code) {
       this.licenseTypes.forEach((lt) => {
         if (lt.code === code) {
+          // eslint-disable-next-line no-param-reassign
           lt.checked = true;
         }
       });

--- a/src/components/HomeLicenseFilter.vue
+++ b/src/components/HomeLicenseFilter.vue
@@ -1,13 +1,13 @@
 <template>
-  <div>
+  <div class="home-license-filter">
     <span>I want something I can</span>
 
-    <div v-for="licenseType in licenseTypes">
-      <label :for="licenseType.code">{{ licenseType.name }}</label>
+    <div class="license-filters" v-for="(licenseType, index) in licenseTypes" :key="index">
       <input :id="licenseType.code"
               type="checkbox"
               :checked="licenseType.checked"
               @input="onFilterChanged(licenseType.code)" />
+      <label :for="licenseType.code">{{ licenseType.name }}</label>
     </div>
   </div>
 </template>
@@ -48,5 +48,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
+.home-license-filter {
+  margin-top: 0.5em;
+  text-align: left;
+}
+span {
+  display: block;
+}
+.license-filters {
+  display: inline-block;
+}
 </style>

--- a/src/components/HomeLicenseFilter.vue
+++ b/src/components/HomeLicenseFilter.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <span>I want something I can</span>
+
+    <div v-for="licenseType in licenseTypes">
+      <label :for="licenseType.code">{{ licenseType.name }}</label>
+      <input :id="licenseType.code"
+              type="checkbox"
+              :checked="licenseType.checked"
+              @input="onFilterChanged(licenseType.code)" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { SET_QUERY } from '@/store/mutation-types';
+
+export default {
+  name: 'license-filter',
+  methods: {
+    onFilterChanged(code) {
+      this.licenseTypes.forEach((lt) => {
+        if (lt.code === code) {
+          lt.checked = true;
+        }
+      });
+      const filter = this.licenseTypes
+        .filter(lt => lt.checked)
+        .map(filterItem => filterItem.code)
+        .join(',');
+
+      this.$store.commit(SET_QUERY, {
+        query: {
+          lt: filter,
+        },
+      });
+    },
+  },
+  data() {
+    return {
+      licenseTypes: [
+        { code: 'commercial', name: 'Use for commercial purposes', checked: false },
+        { code: 'modification', name: 'Modify or adapt', checked: false },
+      ],
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/src/components/NavSection.vue
+++ b/src/components/NavSection.vue
@@ -8,6 +8,7 @@
     <ul class="menu">
       <li><a href="/about">About</a></li>
       <li><a href="/collections">Browse by Collection</a></li>
+      <li id="search-help"><a href="/search-help">Search Guide</a></li>
       <li><a href="/feedback">Feedback</a></li>
       <li class="nav_search" v-if="showNavSearch ==='true'">
         <form class="hero_search-form"
@@ -77,6 +78,10 @@ export default {
   padding: 0;
   list-style: none;
   overflow: hidden;
+}
+
+li {
+  display: block;
 }
 
 .header li a {
@@ -165,8 +170,12 @@ export default {
   top: 0;
 }
 
+#search-help {
+  display: inline-block;
+}
+
 /* 48em = 768px */
-@media (min-width: 48em) {
+@media (min-width: 49em) {
   .header {
     height: 3.9em;
   }
@@ -177,7 +186,7 @@ export default {
     float: right;
   }
   .header li {
-    float: left;
+    display: inline-block;
   }
   .header li a {
     padding: 10px 30px;
@@ -185,6 +194,10 @@ export default {
   .header .menu_icon {
     display: none;
   }
+
+  #search-help {
+  display: none;
+}
 }
 
 .menu a {

--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -15,7 +15,7 @@
           :multiple="true"
           :searchable="false"
           :closeOnSelect="false"
-          :showLabels="false">>
+          :showLabels="false">
         </multiselect>
       </div>
       <div class="filter-option search-filters_licenses">

--- a/test/unit/specs/components/home-license-filter.spec.js
+++ b/test/unit/specs/components/home-license-filter.spec.js
@@ -1,0 +1,38 @@
+import HomeLicenseFilter from '@/components/HomeLicenseFilter';
+import render from '../../test-utils/render';
+
+describe('HomeLicenseFilter', () => {
+  let options = {};
+  let commitMock = null;
+  beforeEach(() => {
+    commitMock = jest.fn();
+    options = {
+      mocks: {
+        $store: {
+          commit: commitMock,
+        },
+      },
+    };
+  });
+
+  it('renders checkboxes', () => {
+    const wrapper = render(HomeLicenseFilter, options);
+    expect(wrapper.find('#commercial').element).toBeDefined();
+    expect(wrapper.find('#modification').element).toBeDefined();
+  });
+
+  it('renders checkboxes', () => {
+    const wrapper = render(HomeLicenseFilter, options);
+    const commercialChk = wrapper.find('#commercial');
+    const modificationChk = wrapper.find('#modification');
+
+    commercialChk.trigger('click');
+    modificationChk.trigger('click');
+
+    expect(commitMock).toHaveBeenCalledWith('SET_QUERY', {
+      query: {
+        lt: 'commercial,modification',
+      },
+    });
+  });
+});


### PR DESCRIPTION
Fixes #297 

Adds the license type filters to the home page, allowing users to filter their search for commercial usage and modify/adapt

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
