### PR TITLE
Run node.js GC after 800mb of garbage has accumulated

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "server": "node server.js",
+    "server": "node --max_old_space_size=800 server.js",
     "dev-insecure": "webpack-dev-server --inline --progress --config build/webpack-dev-conf.js",
     "dev": "webpack-dev-server --https --inline --progress --config build/webpack-dev-conf.js",
     "start": "npm run dev",


### PR DESCRIPTION
The static site rendering node server has been falling over due to using up all of the memory available to its EC2 instances. This configuration change will cause it to kick off garbage collection after 800mb has been used.

There is a chance that there is a memory leak somewhere in the application code, but I think that the default node.js GC threshold is the most likely culprit.