### PR TITLE
#473: add more detailed message when fetching images

### DIFF
--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -28,7 +28,7 @@
         <loading-icon v-show="isFetchingImages" />
       </div>
       <div class="search-grid_notification callout alert" v-if="isFetchingImagesError">
-        <h5>Error fetching images</h5>
+        <h5>Error fetching images: {{ _errorMessage }}</h5>
       </div>
     </div>
   </section>
@@ -93,6 +93,9 @@ export default {
     _imagesCount() {
       const count = this.useInfiniteScroll ? this.$store.state.imagesCount : this.imagesCount;
       return count.toLocaleString('en');
+    },
+    _errorMessage() {
+      return this.$store.state.errorMessage;
     },
     _query() {
       return this.$props.query;

--- a/src/store/search-store.js
+++ b/src/store/search-store.js
@@ -46,6 +46,7 @@ const initialState = (searchParams) => {
     query,
     relatedImages: [],
     relatedImagesCount: 0,
+    errorMessage: '',
   };
 };
 
@@ -107,7 +108,7 @@ const actions = ImageService => ({
         );
       })
       .catch((error) => {
-        commit(FETCH_IMAGES_ERROR);
+        commit(FETCH_IMAGES_ERROR, { errorMessage: error.message });
         throw new Error(error);
       });
   },
@@ -131,7 +132,7 @@ const actions = ImageService => ({
           commit(IMAGE_NOT_FOUND);
         }
         else {
-          commit(FETCH_IMAGES_ERROR);
+          commit(FETCH_IMAGES_ERROR, { errorMessage: error.message });
           throw new Error(error);
         }
       });
@@ -148,7 +149,7 @@ const actions = ImageService => ({
         );
       })
       .catch((error) => {
-        commit(FETCH_IMAGES_ERROR);
+        commit(FETCH_IMAGES_ERROR, { errorMessage: error.message });
         throw new Error(error);
       });
   },
@@ -166,7 +167,7 @@ const actions = ImageService => ({
         );
       })
       .catch((error) => {
-        commit(FETCH_IMAGES_ERROR);
+        commit(FETCH_IMAGES_ERROR, { errorMessage: error.message });
         throw new Error(error);
       });
   },
@@ -194,9 +195,10 @@ const mutations = redirect => ({
   [FETCH_END_IMAGES](_state) {
     _state.isFetchingImages = false;
   },
-  [FETCH_IMAGES_ERROR](_state) {
+  [FETCH_IMAGES_ERROR](_state, params) {
     _state.isFetchingImagesError = true;
     _state.isFetchingImages = false;
+    _state.errorMessage = params.errorMessage;
   },
   [SET_IMAGE](_state, params) {
     _state.image = decodeImageData(params.image);

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -99,10 +99,11 @@ describe('Search Store', () => {
     });
 
     it('FETCH_IMAGES_ERROR updates state', () => {
-      mutations[FETCH_IMAGES_ERROR](state, { errorMessage: undefined });
+      mutations[FETCH_IMAGES_ERROR](state, { errorMessage: 'network error' });
 
       expect(state.isFetchingImages).toBeFalsy();
       expect(state.isFetchingImagesError).toBeTruthy();
+      expect(state.errorMessage).toBe('network error');
     });
 
     it('SET_IMAGE updates state', () => {

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -99,7 +99,7 @@ describe('Search Store', () => {
     });
 
     it('FETCH_IMAGES_ERROR updates state', () => {
-      mutations[FETCH_IMAGES_ERROR](state);
+      mutations[FETCH_IMAGES_ERROR](state, { errorMessage: undefined });
 
       expect(state.isFetchingImages).toBeFalsy();
       expect(state.isFetchingImagesError).toBeTruthy();
@@ -372,7 +372,7 @@ describe('Search Store', () => {
       const action = store.actions(failedMock)[FETCH_IMAGES];
       action({ commit, dispatch, state }, params).catch(() => {
         expect(commit).toBeCalledWith(FETCH_START_IMAGES);
-        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR);
+        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR, { errorMessage: undefined });
         done();
       });
     });
@@ -386,7 +386,7 @@ describe('Search Store', () => {
       const action = store.actions(failedMock)[FETCH_COLLECTION_IMAGES];
       action({ commit }, params).catch(() => {
         expect(commit).toBeCalledWith(FETCH_START_IMAGES);
-        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR);
+        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR, { errorMessage: undefined });
         done();
       });
     });
@@ -443,7 +443,7 @@ describe('Search Store', () => {
       const action = store.actions(failedMock)[FETCH_IMAGE];
       action({ commit, dispatch, state }, params).catch(() => {
         expect(commit).toBeCalledWith(FETCH_START_IMAGES);
-        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR);
+        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR, { errorMessage: undefined });
 
         done();
       });
@@ -488,7 +488,7 @@ describe('Search Store', () => {
       const action = store.actions(failedMock)[FETCH_RELATED_IMAGES];
       action({ commit }, params).catch(() => {
         expect(commit).toBeCalledWith(FETCH_START_IMAGES);
-        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR);
+        expect(commit).toBeCalledWith(FETCH_IMAGES_ERROR, { errorMessage: undefined });
 
         done();
       });


### PR DESCRIPTION
Fixes #473

This wires up error details to the existing "Error fetching images". If there is scenarios I missed please let me know. Here is an image of the additional text:

<img width="989" alt="Screen Shot 2019-10-02 at 3 53 48 PM" src="https://user-images.githubusercontent.com/31563/66037346-0283ec80-e52d-11e9-8887-8f6188694404.png">

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
