### PR TITLE
Change static asset cache duration

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const renderer = createRenderer(bundle, {
 });
 
 const serve = path => express.static(resolve(path), {
-  maxAge: 1000 * 60 * 60 * 24 * 30,
+  maxAge: 1000 * 60 * 60 // 1h static assets cache
 })
 
 server.use('/static', serve('./dist/static'));
@@ -65,7 +65,7 @@ function healthcheck (req, res) {
 // if your app involves user-specific content, you need to implement custom
 // logic to determine whether a request is cacheable based on its url and
 // headers.
-// 1-second microcache.
+// 30-second url response microcache.
 // https://www.nginx.com/blog/benefits-of-microcaching-nginx/
 server.use(microcache.cacheSeconds(30, req => req.originalUrl))
 


### PR DESCRIPTION
Changes the static asset `cache-control max-age` response header to 1 hour. It was 30 days, which is too long.

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
