### PR TITLE
Address Issue #271: Capitalize "search" in Social Share Text

### DIFF
--- a/src/components/ImageSocialShare.vue
+++ b/src/components/ImageSocialShare.vue
@@ -32,7 +32,7 @@ export default {
       return this.image.foreign_landing_url;
     },
     shareText() {
-      return encodeURI(`I found an image through CC search @creativecommons: ${this.imageURL}`);
+      return encodeURI(`I found an image through CC Search @creativecommons: ${this.imageURL}`);
     },
   },
   mounted() {

--- a/test/unit/specs/components/image-social-share.spec.js
+++ b/test/unit/specs/components/image-social-share.spec.js
@@ -36,6 +36,6 @@ describe('ImageSocialShare', () => {
     const wrapper = render(ImageSocialShare, options);
     const url = options.propsData.image.foreign_landing_url;
     expect(wrapper.vm.imageURL).toBe(url);
-    expect(wrapper.vm.shareText).toBe(encodeURI(`I found an image through CC search @creativecommons: ${url}`));
+    expect(wrapper.vm.shareText).toBe(encodeURI(`I found an image through CC Search @creativecommons: ${url}`));
   });
 });


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #271 

This addresses the request in https://github.com/creativecommons/cccatalog-frontend/issues/271 for the image social sharing text to have the word "search" capitalized in the phrase `I found an image through CC Search @creativecommons: `. 

This does not address the part of the issue where sharing on Facebook does not bring up the image social sharing text. This is because the Facebook sharer doesn't look at inputs sent through. E.g. when we send:
`https://www.facebook.com/sharer/sharer.php?u=${shareURL}&t==${shareText}&href=${shareURL}`

It doesn't look at the `shareText` we're sending over. Facebook's sharer has changed to only look at the meta tags on the page. So to fix this issue we likely want  `<meta name="og:description"` to be dynamic and list the sharer text when there's an image on the page, and otherwise list the default `Empowering the world to share through...` text.

I'm not positive how to test this because I think it would require a staging environment for the meta tags to be evaluated and for Facebook's sharer to be able to actually access the page properly. My thought was something along the lines of:
```
<meta name="og:description" content="{{ state.image && state.image.url ? `I found an image through CC Search @creativecommons: ${state.image.url}` : Empowering the world to share through 6 simple licenses + a global community of advocates for open. }}">

```
Please let me know if you have any suggestions regarding the meta tag issue or staging environments that you use. I thought at the very least I could get the capitalization part of the sharing text merged in.
