### PR TITLE
Update Feedback Page

### DIFF
--- a/src/pages/FeedbackPage.vue
+++ b/src/pages/FeedbackPage.vue
@@ -18,12 +18,13 @@
               height="998"
               frameborder="0"
               marginheight="0"
-              marginwidth="0">
+              marginwidth="0"
+              title="feedback form">
               Loading...
       </iframe>
 
       <div>
-        <h1><a id="report"></a>Report a bug</h1>
+        <h2><a id="report"></a>Report a bug</h2>
         <p>
           If you would like to report a bug you are encountering when using the tool, please email
           <a href="mailto:support-search@creativecommons.org">
@@ -65,7 +66,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  h1 {
+  h1, h2 {
     margin-bottom: .44117647em;
     font-size: 2.125em;
     font-weight: normal;


### PR DESCRIPTION
Helps towards fixing #488 

Adds a `title` to the `iframe` for screen readers. Also changes the "Report a bug" `h1` to an `h2`, with the same styling, since a page should only have one `h1`.

#hacktoberfest

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
