### PR TITLE
Revert "Displays image in html "

### DIFF
--- a/src/utils/attributionHtml.js
+++ b/src/utils/attributionHtml.js
@@ -5,10 +5,6 @@ function attributionHtml(image, ccLicenseURL, fullLicenseName) {
   const baseAssetsPath = 'https://search.creativecommons.org/static/img';
   const imgLink = `<a href="${image.foreign_landing_url}">"${image.title}"</a>`;
   let creator = '';
-  let imageTag = '';
-  if (image.url && image.title) {
-    imageTag = `<img style="display: block;" src="${image.url}" alt="${image.title}">`;
-  }
   if (image.creator && image.creator_url) {
     creator = `<span> by <a href="${image.creator_url}">${image.creator}</a></span>`;
   }
@@ -25,7 +21,7 @@ function attributionHtml(image, ccLicenseURL, fullLicenseName) {
   }
 
   const licenseImgLink = `<a href="${ccLicenseURL}" target="_blank" rel="noopener noreferrer" style="display: inline-block;white-space: none;margin-top: 2px;margin-left: 3px;height: 22px !important;">${licenseIcons}</a>`;
-  return `<p style="font-size: 0.9rem;font-style: italic;">${imageTag}${imgLink}${creator}${licenseLink}${licenseImgLink}</p>`;
+  return `<p style="font-size: 0.9rem;font-style: italic;">${imgLink}${creator}${licenseLink}${licenseImgLink}</p>`;
 }
 
 export default attributionHtml;


### PR DESCRIPTION
Reverts creativecommons/cccatalog-frontend#498От dbaa0d08fc8186819a548dbab71441ddcefa39c3 пн сеп 17 00:00:00 2001
От: SomtochiAma <somtochi@grit.systems>
Дата: пет, 27 септември 2019 12:34:45 +0100
Тема: [PATCH] Показва изображение в html

---
 src / utils / attributionHtml.js | 6 +++++ -
 1 файл променен, 5 вмъквания (+), 1 изтриване (-)

diff --git a / src / utils / attributionHtml.js b / src / utils / attributionHtml.js
индекс 9f53403..018ba44 100644
--- a / src / utils / attributionHtml.js
+++ b / src / utils / attributionHtml.js
@@ -5,6 +5,10 @@ функция признаниеHtml (изображение, ccLicenseURL, fullLicenseName) {
   const baseAssetsPath = 'https://search.creativecommons.org/static/img';
   const imgLink = `<a href="${image.foreign_landing_url}">" $ {image.title} "</a>`;
   нека създател = '';
+ нека imageTag = '';
+ ако (image.url && image.title) {
+ imageTag = `<img style =" display: block; " src = "$ {image.url}" alt = "$ {image.title}"> `;
+}
   ако (image.creator && image.creator_url) {
     creator = `<span> от <a href="${image.creator_url}"> $ {image.creator} </a> </span>`;
   }
@@ -21,7 +25,7 @@ функция признаниеHtml (изображение, ccLicenseURL, fullLicenseName) anspage 
   const LicenseImgLink = `<a href =" $ {ccLicenseURL} "target =" _ blank "rel =" noopener noreferrer "style =" display: inline-block; white-space: none; непрозрачност: .7; margin-top: 2px ; марж-ляво: 3px; височина: 22px! важно; "> $ {LicenseIcons}  #</a>`
- връщане `<p style =" font-size: 0.9rem; font-style: italic; "> $ {imgLink} $ {creator} $ {LicenseLink} $ {LicenseImgLink} </p>`;
+ връщане `<p style =" font-size: 0.9rem; font-style: italic; "> $ {imageTag} $ {imgLink} $ {creator} $ {licenceLink} $ {LicenseImgLink} </p>`;
 }
 
 експортиране по подразбиране приписванеHtml; @brenoferreira 