### PR TITLE
Add link to Github repository

### DIFF
--- a/src/components/FooterSection.vue
+++ b/src/components/FooterSection.vue
@@ -40,7 +40,8 @@
                by The Noun Project.</p>
             <p class="website-credit">Website by <a class="subfoot"
                href="https://creativecommons.org"
-            target="blank">CC</a>.</p>
+               target="blank">CC</a>.</p>
+            <p>Contribute on <a href="https://github.com/creativecommons/cccatalog-frontend">GitHub</a>.</p>
           </div>
           </aside>
         </div>


### PR DESCRIPTION
Fixes #443

Result of adding "Contribute on GitHub" in footer:

![Captura de pantalla de 2019-10-21 21-09-12](https://user-images.githubusercontent.com/9145885/67254577-c963db80-f44b-11e9-96ea-47559129415a.png)

New link is at lower right corner referencing [this](https://github.com/creativecommons/cccatalog-frontend) repo.

---

<details>
<summary>Developer Certificate of Origin Version 1.1</summary>

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
</details>