### PR TITLE
Add logo verify at source

### DIFF
--- a/src/components/ImageAttribution.vue
+++ b/src/components/ImageAttribution.vue
@@ -52,7 +52,10 @@
         </CopyButton>
       </div>
       <reuse-survey :image="image" />
-      <legal-disclaimer :source="image.provider" :sourceURL="image.foreign_landing_url" />
+      <legal-disclaimer
+          :source="image.provider"
+          :sourceProviderCode="image.provider_code"
+          :sourceURL="image.foreign_landing_url" />
     </div>
   </section>
 </template>

--- a/src/components/ImageInfo.vue
+++ b/src/components/ImageInfo.vue
@@ -29,15 +29,16 @@
       </li>
       <li>
         <h3>Source</h3>
-        <a class="photo_provider"
-          :href="image.foreign_landing_url"
-          target="blank"
-          rel="noopener noreferrer">
-          <img class="provider-logo"
-               :alt="image.provider"
-               :src="getProviderLogo(image.provider_code)" />
-          {{ image.provider }}
-        </a>
+        <div class="provider-container">
+          <a :href="image.foreign_landing_url"
+              target="blank"
+              rel="noopener noreferrer">
+            <img class="provider-logo"
+                :alt="image.provider"
+                :src="getProviderLogo(image.provider_code)" />
+            <span>{{image.provider}}</span>
+          </a>
+      </div>
       </li>
       <li>
         <h3>Dimensions</h3>

--- a/src/components/ImageInfo.vue
+++ b/src/components/ImageInfo.vue
@@ -29,14 +29,13 @@
       </li>
       <li>
         <h3>Source</h3>
-        <div class="provider-container">
+        <div>
           <a :href="image.foreign_landing_url"
               target="blank"
               rel="noopener noreferrer">
             <img class="provider-logo"
                 :alt="image.provider"
                 :src="getProviderLogo(image.provider_code)" />
-            <span>{{image.provider}}</span>
           </a>
       </div>
       </li>

--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -1,12 +1,13 @@
 <template>
   <div>
-    <div v-if="sourceURL && sourceProviderCode" class="verify-source">
+    <div v-if="sourceURL" class="verify-source">
       <span>Verify at the source:</span>
       <div>
         <a :href="sourceURL"
             target="blank"
             rel="noopener noreferrer">
           <img class="provider-logo"
+              :alt="source"
               :src="getProviderLogo(sourceProviderCode)" />
           <span>{{source}}</span>
         </a>

--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -1,25 +1,21 @@
 <template>
-  <div>
-    <div v-if="sourceURL" class="verify-source">
-      <span>Verify at the source:</span>
-      <div class="provider-container">
-        <a :href="sourceURL"
-            target="blank"
-            rel="noopener noreferrer">
-          <img class="provider-logo"
-              :alt="source"
-              :src="getProviderLogo(sourceProviderCode)" />
-          <span>{{source}}</span>
-        </a>
-      </div>
+  <div v-if="sourceURL" class="provider-container">
+    <span>Verify at the source:</span>
+    <div>
+      <a :href="sourceURL"
+          target="blank"
+          rel="noopener noreferrer">
+        <img class="provider-logo"
+            :alt="source"
+            :src="getProviderLogo(sourceProviderCode)" />
+      </a>
+      <p class="legal-disclaimer">
+        CC Search aggregates data from publicly available repositories of open content.<br />
+        CC does not host the content and does not verify that the content is properly CC-licensed
+        or that the attribution information is accurate or complete.<br />
+        Please follow the link to the source of the content to independently verify before reuse.
+      </p>
     </div>
-
-    <p class="legal-disclaimer">
-      CC Search aggregates data from publicly available repositories of open content.
-      CC does not host the content and does not verify that the content is properly CC-licensed
-      or that the attribution information is accurate or complete. Please follow the link to the
-      source of the content to independently verify before reuse.
-    </p>
   </div>
 </template>
 
@@ -43,9 +39,4 @@ export default {
 
 <style lang="scss" scoped>
   @import '../styles/photodetails.scss';
-
-  .verify-source {
-    font-weight: 600;
-    font-size: 1.1em;
-  }
 </style>

--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -3,7 +3,9 @@
     <div v-if="sourceURL && sourceProviderCode" class="verify-source">
       <span>Verify at the source:</span>
       <div>
-        <a :href="sourceURL">
+        <a :href="sourceURL"
+            target="blank"
+            rel="noopener noreferrer">
           <img class="provider-logo"
               :src="getProviderLogo(sourceProviderCode)" />
           <span>{{source}}</span>

--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -1,6 +1,16 @@
 <template>
   <div>
-    <a :href="sourceURL">Verify at the source: {{ source }}</a>
+    <div v-if="sourceURL && sourceProviderCode" class="verify-source">
+      <span>Verify at the source:</span>
+      <div>
+        <a :href="sourceURL">
+          <img class="provider-logo"
+              :src="getProviderLogo(sourceProviderCode)" />
+          <span>{{source}}</span>
+        </a>
+      </div>
+    </div>
+
     <p class="legal-disclaimer">
       CC Search aggregates data from publicly available repositories of open content.
       CC does not host the content and does not verify that the content is properly CC-licensed
@@ -12,16 +22,37 @@
 
 <script>
 import Tooltip from '@/components/Tooltip';
+import getProviderLogo from '@/utils/getProviderLogo';
 
 export default {
   name: 'legal-disclaimer',
-  props: ['source', 'sourceURL'],
+  props: ['source', 'sourceProviderCode', 'sourceURL'],
   components: {
     Tooltip,
+  },
+  methods: {
+    getProviderLogo(providerName) {
+      return getProviderLogo(providerName);
+    },
   },
 };
 </script>
 
 <style lang="scss" scoped>
   @import '../styles/photodetails.scss';
+
+  .verify-source {
+    font-weight: 600;
+    font-size: 1.1em;
+
+    a {
+      max-width: fit-content;
+      display: flex;
+      align-items: center;
+    }
+
+    img {
+      margin-right: 10px;
+    }
+  }
 </style>

--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -40,19 +40,4 @@ export default {
 
 <style lang="scss" scoped>
   @import '../styles/photodetails.scss';
-
-  .verify-source {
-    font-weight: 600;
-    font-size: 1.1em;
-
-    a {
-      max-width: fit-content;
-      display: flex;
-      align-items: center;
-    }
-
-    img {
-      margin-right: 10px;
-    }
-  }
 </style>

--- a/src/components/LegalDisclaimer.vue
+++ b/src/components/LegalDisclaimer.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-if="sourceURL" class="verify-source">
       <span>Verify at the source:</span>
-      <div>
+      <div class="provider-container">
         <a :href="sourceURL"
             target="blank"
             rel="noopener noreferrer">
@@ -43,4 +43,9 @@ export default {
 
 <style lang="scss" scoped>
   @import '../styles/photodetails.scss';
+
+  .verify-source {
+    font-weight: 600;
+    font-size: 1.1em;
+  }
 </style>

--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -12,10 +12,6 @@
   width: 100%;
 }
 
-.photo_provider {
-  text-transform: capitalize;
-}
-
 .photo {
   width: 100%;
   border-bottom: 1px solid #616161;
@@ -244,6 +240,7 @@ label {
 .provider-container {
   font-weight: 600;
   font-size: 1.1em;
+  text-transform: capitalize;
 
   a {
     max-width: fit-content;

--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -241,7 +241,7 @@ label {
   display: block;
 }
 
-.verify-source {
+.provider-container {
   font-weight: 600;
   font-size: 1.1em;
 

--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -240,3 +240,18 @@ label {
   height: 64px;
   display: block;
 }
+
+.verify-source {
+  font-weight: 600;
+  font-size: 1.1em;
+
+  a {
+    max-width: fit-content;
+    display: flex;
+    align-items: center;
+  }
+
+  img {
+    margin-right: 10px;
+  }
+}

--- a/src/styles/photodetails.scss
+++ b/src/styles/photodetails.scss
@@ -226,6 +226,8 @@ label {
 }
 
 .legal-disclaimer {
+  margin: 0px 20px;
+
   font-size: 0.75rem;
   font-style: italic;
 }
@@ -238,17 +240,17 @@ label {
 }
 
 .provider-container {
-  font-weight: 600;
-  font-size: 1.1em;
-  text-transform: capitalize;
-
-  a {
-    max-width: fit-content;
+  div {
     display: flex;
     align-items: center;
   }
 
+  span {
+    font-weight: 600;
+    font-size: 1.1em;
+  }
+
   img {
-    margin-right: 10px;
+    height: 32px;
   }
 }

--- a/test/unit/specs/components/image-info.spec.js
+++ b/test/unit/specs/components/image-info.spec.js
@@ -39,7 +39,6 @@ describe('Image Info', () => {
     const wrapper = render(ImageInfo, options);
     expect(wrapper.html()).toContain(props.image.title);
     expect(wrapper.find('.photo_license').text()).toBe(props.fullLicenseName);
-    expect(wrapper.find('.provider-container').text()).toBe(props.image.provider);
   });
 
   it('should contain display not available if there is no image creator', () => {

--- a/test/unit/specs/components/image-info.spec.js
+++ b/test/unit/specs/components/image-info.spec.js
@@ -39,7 +39,7 @@ describe('Image Info', () => {
     const wrapper = render(ImageInfo, options);
     expect(wrapper.html()).toContain(props.image.title);
     expect(wrapper.find('.photo_license').text()).toBe(props.fullLicenseName);
-    expect(wrapper.find('.photo_provider').text()).toBe(props.image.provider);
+    expect(wrapper.find('.provider-container').text()).toBe(props.image.provider);
   });
 
   it('should contain display not available if there is no image creator', () => {

--- a/test/unit/specs/components/legal-disclaimer.spec.js
+++ b/test/unit/specs/components/legal-disclaimer.spec.js
@@ -24,7 +24,6 @@ describe('Legal Disclaimer', () => {
   it('displays source', () => {
     const wrapper = render(LegalDisclaimer, options);
     const link = wrapper.find('a');
-    expect(link.text()).toContain(props.source);
     expect(link.attributes().href).toBe(props.sourceURL);
   });
 });


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #409 

I've tried to answer the issue without breaking the existing layout of the section, applying just some small changes. I thought it would make sense to keep consistence between this element and the one in the Info tab, so I adapted the latter to reflect the changes.

I don't know if it's somehow acceptable, of course I'm available for adjustments, changes and further contributions. Feel free to ask!

### UI preview
This is the current result:
![Screenshot from 2019-10-23 16-13-09](https://user-images.githubusercontent.com/27001991/67401896-11037800-f5b0-11e9-9327-105653990b25.png)

This is an alternate version I tried, but I thought the position wasn't quite right for a disclaimer:
![Screenshot from 2019-10-23 14-37-10](https://user-images.githubusercontent.com/27001991/67402058-4c9e4200-f5b0-11e9-8982-5b04ad5b9cb6.png)

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
