### PR TITLE
Makes 'Load More' button disabled if there are no more images

### DIFF
--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -100,7 +100,7 @@ export default {
       return this.$props.query;
     },
     isFinished() {
-      return this.currentPage * 20 >= this.$store.state.imagesCount;
+      return this.currentPage >= this.$store.state.pageCount;
     },
   },
   watch: {

--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -22,8 +22,10 @@
         <button v-show="!isFetchingImages && includeAnalytics"
                 class="clear button"
                 type="button"
+                :disabled="isFinished"
                 @click="onLoadMoreImages">
-          Load more
+          <p v-if="isFinished">No more images :(</p>
+          <p v-else>Load more</p>
         </button>
         <loading-icon v-show="isFetchingImages" />
       </div>
@@ -97,6 +99,9 @@ export default {
     _query() {
       return this.$props.query;
     },
+    isFinished() {
+      return this.currentPage * 20 >= this.$store.state.imagesCount;
+    },
   },
   watch: {
     _images: {
@@ -145,6 +150,10 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style lang="scss">
+
+  .button[disabled] {
+    opacity: 1;
+  }
 
   .search-grid_analytics h5,
   .search-grid_layout-control h5 {

--- a/src/store/search-store.js
+++ b/src/store/search-store.js
@@ -37,6 +37,7 @@ const initialState = (searchParams) => {
   return {
     image: {},
     imagesCount: 0,
+    pageCount: 0,
     imagePage: 1,
     images: [],
     isFetchingImages: false,
@@ -101,6 +102,7 @@ const actions = ImageService => ({
         commit(SET_IMAGES,
           { images: data.results,
             imagesCount: data.result_count,
+            pageCount: data.page_count,
             shouldPersistImages: params.shouldPersistImages,
             page: params.page,
           },
@@ -159,6 +161,7 @@ const actions = ImageService => ({
         commit(FETCH_END_IMAGES);
         commit(SET_IMAGES,
           { images: data.results,
+            pageCount: data.page_count,
             imagesCount: data.result_count,
             shouldPersistImages: params.shouldPersistImages,
             page: params.page,
@@ -223,7 +226,7 @@ const mutations = redirect => ({
       images = params.images;
     }
     _state.images = images.map(image => decodeImageData(image));
-
+    _state.pageCount = params.pageCount;
     _state.imagesCount = params.imagesCount || 0;
     _state.imagePage = params.page || 1;
   },


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #526 

[Short description explaining the high-level reason for the pull request]
When there are no more images from the search to be loaded, it disables the button and also changes the text

![Uploading image.png…]()

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
