### PR TITLE
fixed count for image results >10K #540

### DIFF
--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -4,8 +4,7 @@
     <div class="search-grid_ctr" ref="gridItems">
       <div v-show="!isFetchingImages && includeAnalytics" class="search-grid_analytics" >
         <h2>{{ searchTerm }}</h2>
-        <span v-if="_imagesCount === '10,000'"> Over {{ _imagesCount }} images</span>
-        <span v-else>{{ _imagesCount }} images</span>
+        <span> {{ _imagesCount }}</span>
       </div>
       <div
         class="masonry-layout"
@@ -95,7 +94,8 @@ export default {
     },
     _imagesCount() {
       const count = this.useInfiniteScroll ? this.$store.state.imagesCount : this.imagesCount;
-      return count.toLocaleString('en');
+      const localeCount = count.toLocaleString('en');
+      return localeCount === '10,000' ? `Over ${localeCount} images` : `${localeCount} images`;
     },
     _query() {
       return this.$props.query;

--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -4,7 +4,8 @@
     <div class="search-grid_ctr" ref="gridItems">
       <div v-show="!isFetchingImages && includeAnalytics" class="search-grid_analytics" >
         <h2>{{ searchTerm }}</h2>
-        <span>{{ _imagesCount }} photos</span>
+        <span v-if="_imagesCount === '10,000'"> Over {{ _imagesCount }} images</span>
+        <span v-else>{{ _imagesCount }} images</span>
       </div>
       <div
         class="masonry-layout"

--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -94,8 +94,7 @@ export default {
     },
     _imagesCount() {
       const count = this.useInfiniteScroll ? this.$store.state.imagesCount : this.imagesCount;
-      const localeCount = count.toLocaleString('en');
-      return localeCount === '10,000' ? `Over ${localeCount} images` : `${localeCount} images`;
+      return count >= 10000 ? `Over ${count.toLocaleString('en')} images` : `${count.toLocaleString('en')} images`;
     },
     _query() {
       return this.$props.query;


### PR DESCRIPTION
### Fixes #540

The CC Catalog API has a capped result count of 10,000 even when results exceed this amount. This fix is aimed at helping users understand this by reflecting it on the UI search results count whenever that is the case.

![Screenshot from 2019-12-20 23-01-39](https://user-images.githubusercontent.com/25867872/71295752-8bb4fd80-237d-11ea-891e-2e9820b61715.png)
Screenshot showing updated change to search results count when >10K results

![Screenshot from 2019-12-20 23-02-43](https://user-images.githubusercontent.com/25867872/71295893-1b5aac00-237e-11ea-8b95-fb5729624a8f.png)
Screenshot showing original search result count when <10K results

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
