### PR TITLE
Update code to confirm to API v1

### DIFF
--- a/config/.env
+++ b/config/.env
@@ -2,7 +2,7 @@
 # do not include sensitive data here
 
 NODE_ENV="development"
-API_URL="https://api-dev.creativecommons.engineering"
+API_URL="https://api-dev.creativecommons.engineering/v1/"
 
 BROWSER_SENTRY_DSN="https://0af20fb1afa54fb0a289f51c3ef06b54@sentry.io/1524508"
 SSR_SENTRY_DSN="https://0841dfab481044b9b9b4f25c34c51013@sentry.io/1524517"

--- a/src/api/ImageProviderService.js
+++ b/src/api/ImageProviderService.js
@@ -7,7 +7,7 @@ const ImageProviderService = {
    * SSR-called
   */
   getProviderStats() {
-    return ApiService.get('statistics', 'image');
+    return ApiService.get('', 'sources');
   },
   getProviderInfo(providerName) {
     const PROVIDER_NAME_LOOKUP = {

--- a/src/api/ImageService.js
+++ b/src/api/ImageService.js
@@ -6,11 +6,11 @@ const ImageService = {
    * Search for images by keyword.
    */
   search(params) {
-    return ApiService.query('image/search', params);
+    return ApiService.query('images', params);
   },
 
   getProviderCollection(params) {
-    return ApiService.query(`image/browse/${params.provider}`, params);
+    return ApiService.query('images', params);
   },
 
   /**
@@ -22,7 +22,7 @@ const ImageService = {
       throw new Error('[RWV] ImageService.getImageDetail() id parameter required to retreive image details.');
     }
 
-    return ApiService.get('image', params.id);
+    return ApiService.get('images', params.id);
   },
 
   getRelatedImages(params) {
@@ -30,7 +30,7 @@ const ImageService = {
       throw new Error('[RWV] ImageService.getRelatedImages() id parameter required to retreive related images.');
     }
 
-    return ApiService.get('image/related', params.id);
+    return ApiService.get('recommendations/images', params.id);
   },
 };
 

--- a/src/store/search-store.js
+++ b/src/store/search-store.js
@@ -76,7 +76,9 @@ const fetchCollectionImages = (commit, params, imageService) => {
   // so if the `q`, or any other search filter is provided, and
   // since the `provider` parameter is passed, we can just call the search API instead
   const searchMethod = allKeysUndefinedExcept(queryParams, 'provider') ? imageService.getProviderCollection : imageService.search;
-  return searchMethod(prepareSearchQueryParams(params));
+  const newParams = { ...params, source: params.provider };
+  delete newParams.provider;
+  return searchMethod(prepareSearchQueryParams(newParams));
 };
 
 const actions = ImageService => ({

--- a/src/utils/searchQueryTransform.js
+++ b/src/utils/searchQueryTransform.js
@@ -4,13 +4,13 @@ import { filterData } from '@/store/filter-store';
 import getParameterByName from './getParameterByName';
 
 const filterPropertyMappings = {
-  licenses: 'li',
-  licenseTypes: 'lt',
+  licenses: 'license',
+  licenseTypes: 'license_type',
   categories: 'categories',
   extensions: 'extension',
   aspectRatios: 'aspect_ratio',
   sizes: 'size',
-  providers: 'provider',
+  providers: 'source',
 };
 
 /**

--- a/test/unit/specs/store/filter-store.spec.js
+++ b/test/unit/specs/store/filter-store.spec.js
@@ -41,7 +41,7 @@ describe('Filter Store', () => {
     });
 
     it('gets query from search params', () => {
-      const state = store.state('?q=landscapes&provider=met&li=by&lt=commercial&searchBy=creator');
+      const state = store.state('?q=landscapes&source=met&license=by&license_type=commercial&searchBy=creator');
       expect(state.filters.providers.find(x => x.code === 'met').checked).toBeTruthy();
       expect(state.filters.licenses.find(x => x.code === 'by').checked).toBeTruthy();
       expect(state.filters.licenseTypes.find(x => x.code === 'commercial').checked).toBeTruthy();
@@ -61,7 +61,7 @@ describe('Filter Store', () => {
     });
 
     it('isFilterApplied is set to true when provider filter is set', () => {
-      const state = store.state('?q=landscapes&provider=met&li=by&lt=');
+      const state = store.state('?q=landscapes&source=met&license=by&license_type=');
       expect(state.isFilterApplied).toBeTruthy();
     });
 
@@ -71,12 +71,12 @@ describe('Filter Store', () => {
     });
 
     it('isFilterApplied is set to true when license type filter is set', () => {
-      const state = store.state('?q=landscapes&lt=commercial');
+      const state = store.state('?q=landscapes&license_type=commercial');
       expect(state.isFilterApplied).toBeTruthy();
     });
 
     it('isFilterApplied is set to true when license filter is set', () => {
-      const state = store.state('?q=landscapes&li=by');
+      const state = store.state('?q=landscapes&license=by');
       expect(state.isFilterApplied).toBeTruthy();
     });
 
@@ -139,11 +139,11 @@ describe('Filter Store', () => {
       expect(state.filters.licenses[0].checked).toBeTruthy();
       expect(state.query).toEqual({
         q: 'foo',
-        li: state.filters.licenses[0].code,
+        license: state.filters.licenses[0].code,
         extension: '',
         categories: '',
-        lt: '',
-        provider: '',
+        license_type: '',
+        source: '',
         searchBy: '',
         aspect_ratio: '',
         size: '',
@@ -156,11 +156,11 @@ describe('Filter Store', () => {
       expect(state.filters.licenseTypes[0].checked).toBeTruthy();
       expect(state.query).toEqual({
         q: 'foo',
-        li: '',
+        license: '',
         extension: '',
         categories: '',
-        lt: state.filters.licenseTypes[0].code,
-        provider: '',
+        license_type: state.filters.licenseTypes[0].code,
+        source: '',
         searchBy: '',
         aspect_ratio: '',
         size: '',
@@ -173,11 +173,11 @@ describe('Filter Store', () => {
       expect(state.filters.extensions[0].checked).toBeTruthy();
       expect(state.query).toEqual({
         q: 'foo',
-        li: '',
+        license: '',
         extension: state.filters.extensions[0].code,
         categories: '',
-        lt: '',
-        provider: '',
+        license_type: '',
+        source: '',
         searchBy: '',
         aspect_ratio: '',
         size: '',
@@ -190,11 +190,11 @@ describe('Filter Store', () => {
       expect(state.filters.categories[0].checked).toBeTruthy();
       expect(state.query).toEqual({
         q: 'foo',
-        li: '',
+        license: '',
         extension: '',
         categories: state.filters.categories[0].code,
-        lt: '',
-        provider: '',
+        license_type: '',
+        source: '',
         searchBy: '',
         aspect_ratio: '',
         size: '',
@@ -207,11 +207,11 @@ describe('Filter Store', () => {
       expect(state.filters.searchBy.creator).toBeTruthy();
       expect(state.query).toEqual({
         q: 'foo',
-        li: '',
+        license: '',
         extension: '',
         categories: '',
-        lt: '',
-        provider: '',
+        license_type: '',
+        source: '',
         searchBy: 'creator',
         aspect_ratio: '',
         size: '',
@@ -224,11 +224,11 @@ describe('Filter Store', () => {
       expect(state.filters.aspectRatios[0].checked).toBeTruthy();
       expect(state.query).toEqual({
         q: 'foo',
-        li: '',
+        license: '',
         extension: '',
         categories: '',
-        lt: '',
-        provider: '',
+        license_type: '',
+        source: '',
         searchBy: '',
         aspect_ratio: state.filters.aspectRatios[0].code,
         size: '',
@@ -241,11 +241,11 @@ describe('Filter Store', () => {
       expect(state.filters.sizes[0].checked).toBeTruthy();
       expect(state.query).toEqual({
         q: 'foo',
-        li: '',
+        license: '',
         extension: '',
         categories: '',
-        lt: '',
-        provider: '',
+        license_type: '',
+        source: '',
         searchBy: '',
         aspect_ratio: '',
         size: state.filters.sizes[0].code,

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -30,15 +30,15 @@ describe('Search Store', () => {
     });
 
     it('gets query from search params', () => {
-      const state = store.state('?q=landscapes&provider=met&li=by&lt=all&searchBy=creator&categories=gif&size=large&aspect_ratio=wide');
+      const state = store.state('?q=landscapes&source=met&license=by&license_type=all&searchBy=creator&categories=gif&size=large&aspect_ratio=wide');
       expect(state.imagesCount).toBe(0);
       expect(state.imagePage).toBe(1);
       expect(state.images).toHaveLength(0);
       expect(state.isFetchingImages).toBeFalsy();
       expect(state.isFetchingImagesError).toBeTruthy();
       expect(state.query.q).toBe('landscapes');
-      expect(state.query.provider).toBe('met');
-      expect(state.query.lt).toBe('all');
+      expect(state.query.source).toBe('met');
+      expect(state.query.license_type).toBe('all');
       expect(state.query.searchBy).toBe('creator');
       expect(state.query.categories).toBe('gif');
       expect(state.query.size).toBe('large');
@@ -155,7 +155,7 @@ describe('Search Store', () => {
       mutations[RESET_QUERY](state);
 
       expect(state.query.q).toBe('');
-      expect(state.query.lt).toBe('');
+      expect(state.query.license_type).toBe('');
       expect(state.isFilterApplied).toBeFalsy();
     });
 
@@ -246,7 +246,9 @@ describe('Search Store', () => {
           page: params.page,
         });
 
-        expect(imageServiceMock.getProviderCollection).toBeCalledWith(params);
+        const newParams = { ...params, source: params.provider };
+        delete newParams.provider;
+        expect(imageServiceMock.getProviderCollection).toBeCalledWith(newParams);
         done();
       });
     });
@@ -255,7 +257,9 @@ describe('Search Store', () => {
       const params = { q: 'nature', provider: 'met', page: 1, shouldPersistImages: false };
       const action = store.actions(imageServiceMock)[FETCH_COLLECTION_IMAGES];
       action({ commit, dispatch }, params).then(() => {
-        expect(imageServiceMock.search).toBeCalledWith(params);
+        const newParams = { ...params, source: params.provider };
+        delete newParams.provider;
+        expect(imageServiceMock.search).toBeCalledWith(newParams);
 
         done();
       });
@@ -265,7 +269,9 @@ describe('Search Store', () => {
       const params = { li: 'by', provider: 'met', page: 1, shouldPersistImages: false };
       const action = store.actions(imageServiceMock)[FETCH_COLLECTION_IMAGES];
       action({ commit, dispatch }, params).then(() => {
-        expect(imageServiceMock.getProviderCollection).toBeCalledWith(params);
+        const newParams = { ...params, source: params.provider };
+        delete newParams.provider;
+        expect(imageServiceMock.getProviderCollection).toBeCalledWith(newParams);
 
         done();
       });
@@ -275,7 +281,9 @@ describe('Search Store', () => {
       const params = { lt: 'commercial', provider: 'met', page: 1, shouldPersistImages: false };
       const action = store.actions(imageServiceMock)[FETCH_COLLECTION_IMAGES];
       action({ commit, dispatch }, params).then(() => {
-        expect(imageServiceMock.getProviderCollection).toBeCalledWith(params);
+        const newParams = { ...params, source: params.provider };
+        delete newParams.provider;
+        expect(imageServiceMock.getProviderCollection).toBeCalledWith(newParams);
 
         done();
       });
@@ -285,7 +293,9 @@ describe('Search Store', () => {
       const params = { q: 'nature', provider: 'met', page: 1, shouldPersistImages: false };
       const action = store.actions(imageServiceMock)[FETCH_COLLECTION_IMAGES];
       action({ commit, dispatch }, params).then(() => {
-        expect(imageServiceMock.search).toBeCalledWith(params);
+        const newParams = { ...params, source: params.provider };
+        delete newParams.provider;
+        expect(imageServiceMock.search).toBeCalledWith(newParams);
 
         done();
       });


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #551 

**Changes made**
- Updated API calls from [v0](https://api.creativecommons.engineering/v0/) to [v1](https://api-dev.creativecommons.engineering/v1/)
- Made changes to the different query parameter names, example - provider to sources
- All of the changes have been made either in the `utils/searchQueryTransform.js` or the `store/search-store.js` actions, without affecting the state and props being used by the vue project

**Pending**
- Cannot find endpoint for POST request to `/analytics` in v0 or v1 of the API, but it is being used at `api/UsageDataService.js`
- Response for majority of the API calls are same, have not adjusted for minor tweaks or extra information received like- `attribution` is received in v1, whereas `metadata` is not received, but changes for them haven't been made yet, as I have little idea where to look at.

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
