### PR TITLE
Added CSS styles to fix issue-575

### DIFF
--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -117,7 +117,9 @@ export default {
 .search-filters {
   background: #fafafa;
   display: none;
-  height: 100%;
+  height: auto;
+  top: 0;
+  position: sticky;
 
   label {
     color: #333333;

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -132,6 +132,9 @@ export default {
     width: 100%;
     background: #fff;
     border-bottom: 1px solid #E6EAEA;
+    z-index: 1;
+    top: 0;
+    position: sticky;
   }
 
   .search-filter:after,


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #575 

- As described in the issue, this PR adds a fixed filter sidebar as well as fixed searchbar up top while scrolling.
- This makes it easier to add filters and browse while they are scrolling
- Also it shows a more consistent view of the page, and doesn't leave whitespace there

**Screenshots**
*Initial*
![image](https://user-images.githubusercontent.com/22821480/74601825-5b14ea00-50c8-11ea-85d5-6dc1bc5c2187.png)

*Scrolling*
![image](https://user-images.githubusercontent.com/22821480/74601830-60723480-50c8-11ea-932e-b467e9369e2f.png)

*Hitting the bottom, with filters open*
![image](https://user-images.githubusercontent.com/22821480/74601833-649e5200-50c8-11ea-8a5a-bc602fcb7e0e.png)

**Methodology**
**Sidebar**
- Used the CSS property position as - `postion: sticky` to get this effect
- `position: sticky` has out of box support for all major browsers, without requiring any polyfills, as can be seen [here](https://caniuse.com/#feat=css-sticky)
- Also added `height: auto` since, when various filters are activated, they increase and decrease the filter sidebar height, so to contain that, height adjusted to auto
- Finally, `top: 0` is to set the offset for the sticky behaviour of the sidebar, as to where and when to stick to.

**Searchbar**
- Used `position: sticky` with `top: 0` here as well, but there was an issue of stacking
- To resolve the stacking issue set `z-index: 1` as well

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
