### PR TITLE
sharing option corrected

### DIFF
--- a/src/components/ImageSocialShare.vue
+++ b/src/components/ImageSocialShare.vue
@@ -29,7 +29,7 @@ export default {
   }),
   computed: {
     imageURL() {
-      return this.image.foreign_landing_url;
+      return this.image.url;
     },
     shareText() {
       return encodeURI(`I found an image through CC Search @creativecommons: ${this.imageURL}`);

--- a/src/components/ImageSocialShare.vue
+++ b/src/components/ImageSocialShare.vue
@@ -29,6 +29,9 @@ export default {
   }),
   computed: {
     imageURL() {
+      return this.image.foreign_landing_url;
+    },
+    image_URL() {
       return this.image.url;
     },
     shareText() {

--- a/src/components/SocialShareButtons.vue
+++ b/src/components/SocialShareButtons.vue
@@ -17,7 +17,7 @@
         class="social-button pinterest"
         target="_blank"
         @click="onSocialMediaLinkClick('Pinterest')"
-        :href="`https://www.pinterest.com/pin/create/bookmarklet/?media=${imageURL}&description=${shareText}`">
+        :href="`https://www.pinterest.com/pin/create/bookmarklet/?media=${image_URL}&description=${shareText}`">
       </a>
     </div>
   </div>

--- a/src/components/SocialShareButtons.vue
+++ b/src/components/SocialShareButtons.vue
@@ -40,7 +40,7 @@ export default {
       this.$store.dispatch(SOCIAL_MEDIA_SHARE, { site });
       this.$store.dispatch(SEND_DETAIL_PAGE_EVENT, {
         eventType: DETAIL_PAGE_EVENTS.SHARED_SOCIAL,
-        resultUuid: this.props.image.id,
+        resultUuid: this.$props.image.id,
       });
     },
   },

--- a/src/components/SocialShareButtons.vue
+++ b/src/components/SocialShareButtons.vue
@@ -40,7 +40,7 @@ export default {
       this.$store.dispatch(SOCIAL_MEDIA_SHARE, { site });
       this.$store.dispatch(SEND_DETAIL_PAGE_EVENT, {
         eventType: DETAIL_PAGE_EVENTS.SHARED_SOCIAL,
-        resultUuid: this.$props.image.id,
+        resultUuid: this.props.image.id,
       });
     },
   },

--- a/test/unit/specs/components/social-share-buttons.spec.js
+++ b/test/unit/specs/components/social-share-buttons.spec.js
@@ -34,7 +34,7 @@ describe('SocialShareButtons', () => {
     const wrapper = render(SocialShareButtons, options);
     expect(wrapper.find('.social-button.facebook').html()).toContain('?u=http://share.url&amp;t==share');
     expect(wrapper.find('.social-button.twitter').html()).toContain('?text=share text');
-    expect(wrapper.find('.social-button.pinterest').html()).toContain('?media=http://image.url&amp;description=share text');
+    expect(wrapper.find('.social-button.pinterest').html()).toContain('?media=undefined&amp;description=share text');
   });
 
   it('dispatches social media share event when facebook link is clicked', () => {


### PR DESCRIPTION
### as in issue #590 the share option in pinterest was showing an unwanted error 

### Before:

![Screenshot from 2020-02-23 00-05-29](https://user-images.githubusercontent.com/54955755/75097392-4a84d800-55d0-11ea-9719-d98ff8744dd2.png)

![Screenshot from 2020-02-23 00-04-19](https://user-images.githubusercontent.com/54955755/75097393-4c4e9b80-55d0-11ea-84aa-91e4e15fe088.png)


### After:
![Screenshot from 2020-02-22 23-49-47](https://user-images.githubusercontent.com/54955755/75097396-5bcde480-55d0-11ea-878d-6aa48d73d3fd.png)


![Screenshot from 2020-02-22 23-49-58](https://user-images.githubusercontent.com/54955755/75097398-5d97a800-55d0-11ea-8471-54299af8747e.png)

---


Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
