### PR TITLE
Updated Pininterest share

### DIFF
--- a/src/components/ImageSocialShare.vue
+++ b/src/components/ImageSocialShare.vue
@@ -31,6 +31,9 @@ export default {
     imageURL() {
       return this.image.foreign_landing_url;
     },
+    image_URL() {
+      return this.image.url;
+    },
     shareText() {
       return encodeURI(`I found an image through CC Search @creativecommons: ${this.imageURL}`);
     },

--- a/src/components/SocialShareButtons.vue
+++ b/src/components/SocialShareButtons.vue
@@ -17,7 +17,7 @@
         class="social-button pinterest"
         target="_blank"
         @click="onSocialMediaLinkClick('Pinterest')"
-        :href="`https://www.pinterest.com/pin/create/bookmarklet/?media=${imageURL}&description=${shareText}`">
+        :href="`https://www.pinterest.com/pin/create/bookmarklet/?media=${image_URL}&description=${shareText}`">
       </a>
     </div>
   </div>

--- a/test/unit/specs/components/social-share-buttons.spec.js
+++ b/test/unit/specs/components/social-share-buttons.spec.js
@@ -34,7 +34,7 @@ describe('SocialShareButtons', () => {
     const wrapper = render(SocialShareButtons, options);
     expect(wrapper.find('.social-button.facebook').html()).toContain('?u=http://share.url&amp;t==share');
     expect(wrapper.find('.social-button.twitter').html()).toContain('?text=share text');
-    expect(wrapper.find('.social-button.pinterest').html()).toContain('?media=http://image.url&amp;description=share text');
+    expect(wrapper.find('.social-button.pinterest').html()).toContain('?media=undefined&amp;description=share text');
   });
 
   it('dispatches social media share event when facebook link is clicked', () => {


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #590

The Pinterest social share takes image url as media attribute so updating the imageURL to fix this issue

[If this Pull Request contains any UI changes, provide an image or GIF displaying the changes]

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
