### PR TITLE
fix autofocus of hero search

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -8,7 +8,7 @@
           v-on:submit.prevent="onSubmit">
       <div class="is-hidden-touch">
         <input required="required"
-                autofocus="true"
+                v-focus
                 class="hero_search-input input is-large"
                 type="search"
                 name="q"
@@ -20,7 +20,7 @@
       </div>
       <div class="is-hidden-desktop">
         <input required="required"
-                autofocus="true"
+                v-focus
                 class="hero_search-input input"
                 type="search"
                 name="q"
@@ -76,6 +76,15 @@ export default {
       this.$store.commit(SET_QUERY, { query: { q: this.form.searchTerm }, shouldNavigate: true });
     },
   },
+  directives: {
+  //directive to add autofocus
+  focus: {
+    // directive definition
+    inserted: function (el) {
+      el.focus()
+    }
+  }
+}
 };
 </script>
 


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes 659

[Short description explaining the high-level reason for the pull request]
This pull request solves the issue of autofocus and input value of search field in hero being disabled and removed on full page load. It also solves an additional issue of navigating back to the search page via vue-router without removing focus

---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
