### PR TITLE
search help link

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -123,7 +123,7 @@ $hero-height: 71vh;
 
 .search-help-link {
   position: absolute;
-  bottom: 2rem;
+  bottom: 4.5rem;
   right: 2rem;
 
   @media screen and (max-width: 40em) {


### PR DESCRIPTION

Fixes #677

I have changed the value of bottom attribute from 2rem to 4.5 rem.

I have checked on both the OS : windows 10 and ubuntu 18.04, and on browsers : chrome and firefox.

Initially in windows, on opening the site, this links was getting hidden under the footer section , but now, whatever be the screen size and if the browser is set to 100%, it will not get hidden, untill user zooms the browser to 125%.