### PR TITLE
Fix filter icon for mobile view

### DIFF
--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -118,5 +118,10 @@ export default {
     .search-form_input {
       font-size: 18px;
     }
+
+    i > img {
+    height : auto;
+    width: 5rem;
+  }
   }
 </style>


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #776 
The filter icon was not visible in mobile view

![Screenshot from 2020-03-21 02-28-07](https://user-images.githubusercontent.com/42486853/77205827-aaad6200-6b1b-11ea-919b-63dc152f46c7.png)


---

Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 1 Letterman Drive Suite D4700 San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
