### PR TITLE
#232 - Added unit tests for FilterChecklist component

### DIFF
--- a/test/unit/specs/components/filter-checklist.spec.js
+++ b/test/unit/specs/components/filter-checklist.spec.js
@@ -1,0 +1,78 @@
+import FilterChecklist from '@/components/FilterChecklist';
+import render from '../../test-utils/render';
+
+describe('FilterChecklist', () => {
+  let options = {};
+  let props = null;
+
+  const eventData = {
+    target: {
+      id: 'foo',
+    },
+  };
+
+  beforeEach(() => {
+    props = {
+      options: [{ code: 'foo', name: 'bar', checked: false }],
+      title: 'Foo',
+      filterType: 'bar',
+      disabled: false,
+    };
+    options = {
+      propsData: props,
+    };
+  });
+
+  it('should render correct contents', () => {
+    const wrapper = render(FilterChecklist, options);
+    expect(wrapper.find('.filters').vm).toBeDefined();
+  });
+
+  it('should render filter visibility toggle button', () => {
+    const wrapper = render(FilterChecklist, options);
+    expect(wrapper.find('.filter-visibility-toggle').element).toBeDefined();
+  });
+
+  it('visibility toggle button should be in collapsed state by default', () => {
+    const wrapper = render(FilterChecklist, options);
+    expect(wrapper.find('.rotImg').element).toBeUndefined();
+  });
+
+  it('shows checklist when visibility toggle button clicked', () => {
+    const wrapper = render(FilterChecklist, options);
+    wrapper.find('.filter-visibility-toggle').trigger('click');
+    expect(wrapper.find('.filter-checkbox').element).toBeDefined();
+    expect(wrapper.find('.rotImg').element).toBeDefined(); // toggle image should point up now
+  });
+
+  it('hides checklist when visibility toggle button pressed twice', () => {
+    const wrapper = render(FilterChecklist, options);
+    wrapper.find('.filter-visibility-toggle').trigger('click'); // should open
+    wrapper.find('.filter-visibility-toggle').trigger('click'); // should close
+    expect(wrapper.find('.filter-checkbox').element).toBeUndefined();
+    expect(wrapper.find('.rotImg').element).toBeUndefined();
+  });
+
+  it('should call filterChanged event', () => {
+    const mockMethods = {
+      onValueChange: jest.fn(),
+    };
+    options.methods = mockMethods;
+
+    const wrapper = render(FilterChecklist, options);
+    wrapper.setData({ filtersVisible: true });
+
+    const checkbox = wrapper.find('.filter-checkbox');
+    expect(checkbox.element).toBeDefined();
+
+    checkbox.trigger('change');
+    expect(options.methods.onValueChange).toHaveBeenCalled();
+  });
+
+  it('should emit filterChanged event', () => {
+    const wrapper = render(FilterChecklist, options);
+    wrapper.vm.onValueChange(eventData);
+    expect(wrapper.emitted().filterChanged).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #232 by @brenoferreira 

## Description
Added unit tests for FilterChecklist component (100% coverage)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository.
- [ ] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
