### PR TITLE
Added route guard to /search to fallback to the HomePage

### DIFF
--- a/src/router/client.js
+++ b/src/router/client.js
@@ -19,6 +19,9 @@ const router = new VueRouter({
       path: '/search',
       name: 'browse-page',
       component: BrowsePage,
+      meta: {
+        requireParams: true,
+      },
       props: route => ({ query: route.query.q }),
     },
     {
@@ -78,6 +81,25 @@ const router = new VueRouter({
     }
     return { x: 0, y: 0 };
   },
+});
+// search route guard
+router.beforeEach((to, _from, next) => {
+  // check to see if route needs any requireParams
+  if (to.matched.some(routeObject => routeObject.meta.requireParams)) {
+    // check if the query has the q
+    if (to.query.q) {
+      // if q is present then preceed
+      next();
+    }
+    else {
+      next({
+        name: 'home-page',
+      });
+    }
+  }
+  else {
+    next();
+  }
 });
 
 router.afterEach((to) => {


### PR DESCRIPTION
## Fixes
Fixes #853 by me

## Description
As said in the issue if anyone goes to just `/search` then they had a blank screen instead of that now they will get redirected to the HomePage

## Technical details
Added route guard to the `/search` route which ensures that query parameters are passed

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
