### PR TITLE
Fix search form layout

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -6,8 +6,10 @@
           method="get"
           action="/search"
           v-on:submit.prevent="onSubmit">
-      <div class="is-hidden-touch is-flex centered-search-box">
-        <input required="required"
+      <div class="is-hidden-touch centered-search-box">
+        <div class="field has-addons">
+          <div class="control">
+            <input required="required"
                 class="hero_search-input input is-large"
                 type="search"
                 name="q"
@@ -15,18 +17,28 @@
                 autocapitalize="none"
                 id="searchTerm"
                 v-model.lazy="form.searchTerm" />
-        <button class="button is-primary big" title="Search">Search</button>
+          </div>
+          <div class="control">
+            <button class="button is-primary big" title="Search">Search</button>
+          </div>
+        </div>
       </div>
-      <div class="is-hidden-desktop is-flex centered-search-box">
-        <input required="required"
-                class="hero_search-input input"
+      <div class="is-hidden-desktop centered-search-box">
+        <div class="field has-addons">
+          <div class="control mobile-input">
+            <input required="required"
+                class="input"
                 type="search"
                 name="q"
                 placeholder="I would like to see..."
                 autocapitalize="none"
                 id="searchTerm"
                 v-model.lazy="form.searchTerm" />
-        <button class="button is-primary small" title="Search">Search</button>
+          </div>
+          <div class="control">
+            <button class="button is-primary small" title="Search">Search</button>
+          </div>
+        </div>
       </div>
       <div class="caption has-text-centered margin-top-big">
         <p>
@@ -102,7 +114,11 @@ $hero-height: 74vh;
   }
 
   .hero_search-input {
-    width: 70%;
+    width: 570px;
+  }
+
+  .mobile-input {
+    width: 100%;
   }
 }
 

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -10,20 +10,24 @@
         <i v-if="!isFilterApplied" class="icon sliders" />
         <i v-else class="icon sliders has-color-dark-slate-blue has-text-weight-semibold" />
       </button>
-      <div class="control has-icons-left search-form_input margin-left-small">
-        <input id="searchInput"
-                required="required"
-                class="input is-medium"
-                type="search"
-                ref="search"
-                :placeholder="searchBoxPlaceholder"
-                v-model="searchTermsModel"
-                @keyup.enter="onSubmit" />
-        <span class="icon is-medium is-left">
-          <i class="icon search is-size-5"></i>
-        </span>
+      <div class="field has-addons search-input">
+        <div class="control has-icons-left margin-left-small">
+          <input id="searchInput"
+                  required="required"
+                  class="input is-medium"
+                  type="search"
+                  ref="search"
+                  :placeholder="searchBoxPlaceholder"
+                  v-model="searchTermsModel"
+                  @keyup.enter="onSubmit" />
+          <span class="icon is-medium is-left">
+            <i class="icon search is-size-5"></i>
+          </span>
+        </div>
+        <div class="control">
+          <input type="submit" class="button is-primary" @click.prevent="onSubmit" value="Search" />
+        </div>
       </div>
-      <input type="submit" class="button is-primary" @click.prevent="onSubmit" value="Search" />
     </div>
     <div class="is-flex is-hidden-desktop">
       <button class="button small toggle-filter-small padding-small"
@@ -32,20 +36,24 @@
         <i v-if="!isFilterApplied" class="icon sliders" />
         <i v-else class="icon sliders has-color-dark-slate-blue has-text-weight-semibold" />
       </button>
-      <div class="control has-icons-left search-form_input margin-left-small">
-        <input id="searchInput"
-                required="required"
-                class="input search-form_input"
-                type="search"
-                ref="search"
-                :placeholder="searchBoxPlaceholder"
-                v-model="searchTermsModel"
-                @keyup.enter="onSubmit">
-        <span class="icon is-left">
-          <i class="icon search is-size-6"></i>
-        </span>
+      <div class="field has-addons search-input">
+        <div class="control has-icons-left margin-left-small">
+          <input id="searchInput"
+                  required="required"
+                  class="input"
+                  type="search"
+                  ref="search"
+                  :placeholder="searchBoxPlaceholder"
+                  v-model="searchTermsModel"
+                  @keyup.enter="onSubmit">
+          <span class="icon is-left">
+            <i class="icon search is-size-6"></i>
+          </span>
+        </div>
+        <div class="control">
+          <input type="submit" class="button is-primary small" value="Search" />
+        </div>
       </div>
-      <input type="submit" class="button is-primary small" value="Search" />
     </div>
   </form>
 </template>
@@ -130,10 +138,14 @@ export default {
     z-index: 10;
   }
 
-  .search-form_input {
-    width: 45%;
+  .search-input {
+    width: 70%;
 
     @media (max-width: 64em) {
+      width: 100%;
+    }
+
+    .control:first-child {
       width: 100%;
     }
   }


### PR DESCRIPTION
Fixes #793 by @panchovm 

Uses Bulma's Form addons to fix the styling issue https://bulma.io/documentation/form/general/#form-addons

<img width="1055" alt="Screen Shot 2020-04-14 at 15 58 57" src="https://user-images.githubusercontent.com/707019/79263234-deed1780-7e68-11ea-98ce-88c2d586b310.png">

<img width="1534" alt="Screen Shot 2020-04-14 at 15 59 15" src="https://user-images.githubusercontent.com/707019/79263251-e6142580-7e68-11ea-8a14-9c5e37b0fc98.png">


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
