### PR TITLE
Added filter tags component for the user to see the filters selected

### DIFF
--- a/src/components/SearchGridFilterTags.vue
+++ b/src/components/SearchGridFilterTags.vue
@@ -1,0 +1,64 @@
+<template>
+    <div class="level columns margin-top-small">
+      <div class="column">
+        <b class="margin-right-small">Filter by</b>
+        <span
+        v-for="(filter,index) in appliedFilters"
+        :key="index">
+            <button class="button tag margin-right-small"
+            v-on:click.prevent="onTagClicked(filter.code , filter.type)">
+                <!-- #10005 is the utf-8 unicode for `x` mark -->
+                {{ filter.name }}&nbsp; &#10005;
+            </button>
+        </span>
+
+        <button class="button tag" v-on:click.prevent="onClearFilters">Clear filters</button>
+      </div>
+    </div>
+</template>
+<script>
+import { TOGGLE_FILTER } from '@/store/action-types';
+import { CLEAR_FILTERS } from '@/store/mutation-types';
+
+export default {
+  name: 'search-grid-filter-tags',
+  computed: {
+    appliedFilters() {
+      const appliedFilters = [];
+      const filters = this.$store.state.filters;
+      Object.keys(filters).forEach((key) => {
+        if (filters[key].creator === undefined) {
+          filters[key].forEach((element) => {
+            if (element.checked) {
+              // eslint-disable-next-line no-param-reassign
+              element.type = key;
+              appliedFilters.push(element);
+            }
+          });
+        }
+        else {
+          // eslint-disable-next-line no-lonely-if
+          if (filters[key].creator) {
+            appliedFilters.push({ name: 'Search by Creator', type: 'searchBy' });
+          }
+        }
+      });
+      return appliedFilters;
+    },
+  },
+  methods: {
+    onTagClicked(code, filterType) {
+      this.$store.dispatch(TOGGLE_FILTER, {
+        code,
+        filterType,
+        shouldNavigate: true,
+      });
+    },
+    onClearFilters() {
+      this.$store.commit(CLEAR_FILTERS, {
+        shouldNavigate: true,
+      });
+    },
+  },
+};
+</script>

--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -55,11 +55,13 @@
         </div>
       </div>
     </div>
+    <SearchGridFilterTags v-if="isFilterApplied" />
   </form>
 </template>
 
 <script>
 import SearchGridFilter from '@/components/SearchGridFilter';
+import SearchGridFilterTags from '@/components/SearchGridFilterTags';
 import { SET_FILTER_IS_VISIBLE } from '@/store/mutation-types';
 
 export default {
@@ -72,6 +74,7 @@ export default {
   data: () => ({ searchTermsModel: null }),
   components: {
     SearchGridFilter,
+    SearchGridFilterTags,
   },
   computed: {
     searchTerms() {


### PR DESCRIPTION
## Fixes
Fixes #797 by @panchovm

## Description
This `PR` adds the filter tags which the user can see and remove by clicking

## Screenshots
![filters_ccfrontend](https://user-images.githubusercontent.com/43946715/79471952-e0f9d680-8020-11ea-933a-45f005f2a7fa.png)

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open-source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open-source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>