### PR TITLE
Moved search guide link to navbar

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -49,17 +49,10 @@
       </div>
       <home-license-filter />
     </form>
-    <div class="help-links">
+    <div class="help-links is-hidden-mobile">
       <span class="margin-right-bigger">
         Go to the
         <a href="https://oldsearch.creativecommons.org/">old CC Search</a> portal
-      </span>
-
-      <span>
-        See our
-        <a href="/search-help">
-          Search Syntax Guide
-        </a>
       </span>
     </div>
   </div>
@@ -124,12 +117,8 @@ $hero-height: 74vh;
 
 .help-links {
   position: absolute;
-  bottom: 5rem;
-  left: 2rem;
-
-  @media screen and (max-width: 40em) {
-    display: none;
-  }
+  bottom: 1rem;
+  left: 1rem;
 }
 
 .help-icon {

--- a/src/components/NavSection.vue
+++ b/src/components/NavSection.vue
@@ -32,7 +32,7 @@
       <div class="navbar-end">
         <a class="navbar-item" href="/about">About</a>
         <a class="navbar-item" href="/collections">Collections</a>
-        <a class="navbar-item is-hidden-desktop" href="/search-help">Search Guide</a>
+        <a class="navbar-item" href="/search-help">Search Guide</a>
         <a class="navbar-item" href="/feedback">Feedback</a>
       </div>
     </div>


### PR DESCRIPTION
Fixes #856  by @Abbas-000

On a new design we moved the search guide to the navbar, so that addresses the issue of overlapping links.

<img width="826" alt="Screen Shot 2020-04-23 at 09 34 00" src="https://user-images.githubusercontent.com/707019/80099892-92c76480-8545-11ea-9dbc-285a7c895fff.png">


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
