### PR TITLE
Fix back button on dmca notice

### DIFF
--- a/src/components/ContentReport/DmcaNotice.vue
+++ b/src/components/ContentReport/DmcaNotice.vue
@@ -10,7 +10,7 @@
       <a :href="imageURL" target="_blank" rel="noopener">at the source {{ providerName }}</a>.
     </span>
 
-    <button class="button is-text tiny margin-top-normal is-shadowless"
+    <button class="button is-text is-block tiny margin-top-normal is-shadowless"
             @click="onBackClick()">
       <span><i class="icon chevron-left margin-right-small"></i> Back</span>
     </button>


### PR DESCRIPTION
Quick fix to a broken back button 

<img width="428" alt="Screen Shot 2020-04-28 at 13 53 20" src="https://user-images.githubusercontent.com/707019/80514987-a9135d00-8957-11ea-8c71-7f7fcab62a15.png">

_broken_

<img width="415" alt="Screen Shot 2020-04-28 at 13 53 06" src="https://user-images.githubusercontent.com/707019/80514998-ab75b700-8957-11ea-9d61-fe02d4b29286.png">

_fixed_

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
