### PR TITLE
Revert "Added Scroll bar to filters for desktop users"

### DIFF
--- a/src/components/SearchGridFilter.vue
+++ b/src/components/SearchGridFilter.vue
@@ -124,8 +124,6 @@ export default {
   }
 
   &__visible {
-    height: 100vh;
-    overflow-y: scroll;
     border-top: 1px solid #e8e8e8;
     display: block;
   }


### PR DESCRIPTION
Reverts creativecommons/cccatalog-frontend#903

This introduced a bug on mobile because of the `height` style.
<img width="366" alt="Screen Shot 2020-04-29 at 16 33 17" src="https://user-images.githubusercontent.com/707019/80638681-37aadb80-8a37-11ea-840a-640f8708057a.png">
