### PR TITLE
showing 'Use' when audio or video is open

### DIFF
--- a/src/components/Filters/FiltersList.vue
+++ b/src/components/Filters/FiltersList.vue
@@ -25,6 +25,7 @@
         @filterChanged="onUpdateFilter"
       />
       <filter-check-list
+        v-if="activeTab == 'image'"
         :options="filters.licenses"
         :disabled="licensesDisabled"
         title="Licenses"
@@ -32,31 +33,35 @@
         @filterChanged="onUpdateFilter"
       />
       <filter-check-list
-        v-if="renderProvidersFilter"
+        v-if="renderProvidersFilter && activeTab == 'image'"
         :options="filters.providers"
         title="Sources"
         filterType="providers"
         @filterChanged="onUpdateFilter"
       />
       <filter-check-list
+        v-if="activeTab == 'image'"
         :options="filters.categories"
         title="Image Type"
         filterType="categories"
         @filterChanged="onUpdateFilter"
       />
       <filter-check-list
+        v-if="activeTab == 'image'"
         :options="filters.extensions"
         title="File Type"
         filterType="extensions"
         @filterChanged="onUpdateFilter"
       />
       <filter-check-list
+        v-if="activeTab == 'image'"
         :options="filters.aspectRatios"
         title="Aspect Ratio"
         filterType="aspectRatios"
         @filterChanged="onUpdateFilter"
       />
       <filter-check-list
+        v-if="activeTab == 'image'"
         :options="filters.sizes"
         title="Image Size"
         filterType="sizes"
@@ -131,5 +136,10 @@ export default {
       this.$emit('onClearFilters')
     },
   },
+  computed: {
+    activeTab() {
+      return this.$route.path.split('search/')[1] || 'image'
+   },
+ },
 }
 </script>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Partially Fixes #1050  


## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

<img width="1256" alt="Screenshot 2020-07-20 at 12 10 04 AM" src="https://user-images.githubusercontent.com/55599878/87882391-578de200-ca1d-11ea-96d1-c3bbdf994eba.png">




## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
