### PR TITLE
Update vue router and fix internal links to be `<router-link>`s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23616,9 +23616,9 @@
       }
     },
     "vue-router": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.6.tgz",
-      "integrity": "sha512-GYhn2ynaZlysZMkFE5oCHRUTqE8BWs/a9YbKpNLi0i7xD6KG1EzDqpHQmv1F5gXjr8kL5iIVS8EOtRaVUEXTqA=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.3.4.tgz",
+      "integrity": "sha512-SdKRBeoXUjaZ9R/8AyxsdTqkOfMcI5tWxPZOUX5Ie1BTL5rPSZ0O++pbiZCeYeythiZIdLEfkDiQPKIaWk5hDg=="
     },
     "vue-server-renderer": {
       "version": "2.6.11",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vue-form": "^4.10.3",
     "vue-masonry": "^0.11.7",
     "vue-meta": "^2.4.0",
-    "vue-router": "^3.1.6",
+    "vue-router": "^3.3.4",
     "vue-server-renderer": "^2.6.11",
     "vuex": "^3.1.3"
   },

--- a/src/components/CollectionItem.vue
+++ b/src/components/CollectionItem.vue
@@ -3,20 +3,20 @@
     class="column is-narrow margin-normal has-background-white provider-card"
   >
     <div>
-      <a
-        :href="'/collections/' + provider.source_name"
+      <router-link
+        :to="'/collections/' + provider.source_name"
         class="provider-name has-text-weight-normal has-text-black"
       >
         {{ provider.display_name }}
-      </a>
+      </router-link>
     </div>
     <div class="provider-logo">
-      <a :href="'/collections/' + provider.source_name">
+      <router-link :to="'/collections/' + provider.source_name">
         <img
           :alt="provider.display_name"
           :src="getProviderLogo(provider.source_name)"
         />
-      </a>
+      </router-link>
     </div>
     <div>
       <span class="has-text-grey-light has-text-weight-semibold">

--- a/src/components/MetaSearch/MetaSourceList.vue
+++ b/src/components/MetaSearch/MetaSourceList.vue
@@ -33,9 +33,6 @@ export default {
       return getLegacySourceUrl(this.type)(source, this.query)
     },
   },
-  mounted() {
-    console.log(legacySourceMap)
-  },
   data() {
     return {
       sources: Object.keys(legacySourceMap).filter(

--- a/src/components/NavSection.vue
+++ b/src/components/NavSection.vue
@@ -1,9 +1,9 @@
 <template>
   <nav aria-label="primary" class="navbar small">
     <div class="navbar-brand">
-      <a class="logo" href="/">
+      <router-link class="logo" to="/">
         <img alt="Logo" src="/static/logos/products/search.svg" />
-      </a>
+      </router-link>
       <a
         role="button"
         :class="{ ['navbar-burger']: true, ['is-active']: isBurgerMenuActive }"
@@ -43,10 +43,14 @@
         </form>
       </div>
       <div class="navbar-end">
-        <a class="navbar-item" href="/about">About</a>
-        <a class="navbar-item" href="/collections">Collections</a>
-        <a class="navbar-item" href="/search-help">Search Guide</a>
-        <a class="navbar-item" href="/feedback">Feedback</a>
+        <router-link class="navbar-item" to="/about">About</router-link>
+        <router-link class="navbar-item" to="/collections"
+          >Collections</router-link
+        >
+        <router-link class="navbar-item" to="/search-help"
+          >Search Guide</router-link
+        >
+        <router-link class="navbar-item" to="/feedback">Feedback</router-link>
         <a
           class="navbar-item"
           href="https://opensource.creativecommons.org/ccsearch-browser-extension/"

--- a/src/components/SearchGridCell.vue
+++ b/src/components/SearchGridCell.vue
@@ -7,8 +7,8 @@
   >
     <figure class="search-grid_item">
       <i :style="`padding-bottom:${iPadding}%`"></i>
-      <a
-        :href="'/photos/' + image.id"
+      <router-link
+        :to="'/photos/' + image.id"
         @click="onGotoDetailPage($event, image)"
         class="search-grid_image-ctr"
         :style="`width: ${imageWidth}%; top: ${imageTop}%; left:${imageLeft}%;`"
@@ -23,7 +23,7 @@
           :src="getImageUrl(image)"
           @error="onImageLoadError($event, image)"
         />
-      </a>
+      </router-link>
       <figcaption class="overlay overlay__top padding-small">
         <license-icons :license="image.license"></license-icons>
       </figcaption>

--- a/test/unit/specs/components/collection-item.spec.js
+++ b/test/unit/specs/components/collection-item.spec.js
@@ -7,14 +7,6 @@ describe('CollectionItem', () => {
     source_name: 'met',
     image_count: 10000,
   }
-  it('should render correct contents', () => {
-    const wrapper = render(CollectionItem, {
-      propsData: {
-        provider,
-      },
-    })
-    expect(wrapper.find('a').element.href).toContain('/collections/met')
-  })
 
   it('should format provider count', () => {
     const wrapper = render(CollectionItem, {


### PR DESCRIPTION
Some small pre-release cleanup to routing:

- Version bump `vue-router`
- Switch internal links to be `<router-link>`s instead of `<a>` tags (the preferred approach by vue)

This will likely fix some sentry errors outlined in #1042.

Also removed a stray `console.log` from a previous commit.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
