### PR TITLE
Add label for use filters

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -27,7 +27,7 @@ export default {
 <style lang="scss" scoped>
 .modal {
   max-width: 80vw;
-  max-height: 80vh;
+  max-height: 84vh;
   margin: 0px auto;
   background-color: #fff;
   border-radius: 2px;

--- a/src/components/MetaSearch/MetaSearchForm.vue
+++ b/src/components/MetaSearch/MetaSearchForm.vue
@@ -6,7 +6,8 @@
       </h4>
       <p>
         Click on a source below to directly search other collections of
-        CC-licensed {{ type }}.
+        CC-licensed {{ type }}.<br />Please note that Use filters are not
+        supported for {{ unsupportedByUsefilter }}.
       </p>
     </header>
 
@@ -35,6 +36,13 @@ export default {
     MetaSourceList,
   },
   computed: {
+    unsupportedByUsefilter() {
+      if (this.type === 'audio') {
+        return 'CC Mixter, Jamendo, or Wikimedia Commons'
+      }
+      if (this.type === 'video') return 'Wikimedia Commons or Youtube'
+      return ''
+    },
     metaQuery() {
       return {
         q: this.query.q,

--- a/src/components/MetaSearch/MetaSearchModal.vue
+++ b/src/components/MetaSearch/MetaSearchModal.vue
@@ -6,7 +6,8 @@
       <h3>Search images from other sources</h3>
       <p>
         Click on a source below to directly search other collections of
-        CC-licensed images
+        CC-licensed images.<br />Please note that Use filters are not supported
+        for Open Clip Art Library.
       </p>
     </header>
     <hr class="margin-bottom-bigger" />


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1082 by @kgodey (@annatuma)

Adds a disclaimer for application of the 'use' filters to meta search.

## Screenshots

<img width="833" alt="Screen Shot 2020-07-24 at 1 38 34 PM" src="https://user-images.githubusercontent.com/6351754/88419769-bc499380-cdb3-11ea-9d46-da773acf0095.png">
<img width="616" alt="Screen Shot 2020-07-24 at 1 38 38 PM" src="https://user-images.githubusercontent.com/6351754/88419770-bce22a00-cdb3-11ea-8ff2-5d74eea0d09a.png">
<img width="790" alt="Screen Shot 2020-07-24 at 1 38 56 PM" src="https://user-images.githubusercontent.com/6351754/88419771-bce22a00-cdb3-11ea-8365-8c05aef174fd.png">



<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
