### PR TITLE
Fix img width/height detection

### DIFF
--- a/src/components/SearchGridCell.vue
+++ b/src/components/SearchGridCell.vue
@@ -21,6 +21,7 @@
           }"
           :alt="image.title"
           :src="getImageUrl(image)"
+          @load="getImgDimension"
           @error="onImageLoadError($event, image)"
         />
       </router-link>
@@ -134,13 +135,10 @@ export default {
         element.src = errorImage
       }
     },
-    getImgDimension() {
-      this.imgHeight = this.$refs.img.naturalHeight
-      this.imgWidth = this.$refs.img.naturalWidth
+    getImgDimension(e) {
+      this.imgHeight = e.target.naturalHeight
+      this.imgWidth = e.target.naturalWidth
     },
-  },
-  mounted() {
-    if (!this.image.width) this.getImgDimension()
   },
 }
 </script>


### PR DESCRIPTION
# Fixes

Fixes #1084 by @zackkrida 

Fixes how img width/height is calculated to fix the existing masonry-style flexbox layout.

> before
<img width="1695" alt="Screen Shot 2020-07-27 at 8 23 48 AM" src="https://user-images.githubusercontent.com/6351754/88541318-8ccc9e00-cfe2-11ea-83dd-896f9c2a5323.png">


> after
<img width="1695" alt="Screen Shot 2020-07-27 at 8 23 57 AM" src="https://user-images.githubusercontent.com/6351754/88541329-8fc78e80-cfe2-11ea-8b44-3841f9589639.png">


<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
