### PR TITLE
Use source logos from api

### DIFF
--- a/src/components/CollectionItem.vue
+++ b/src/components/CollectionItem.vue
@@ -46,7 +46,7 @@ export default {
       const provider = ImageProviderService.getProviderInfo(providerName)
       if (provider) {
         const logo = provider.logo
-        const logoUrl = require(`@/assets/${logo}`) // eslint-disable-line global-require, import/no-dynamic-require
+        const logoUrl = this.provider.logo_url || require(`@/assets/${logo}`) // eslint-disable-line global-require, import/no-dynamic-require
 
         return logoUrl
       }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1035 by @annatuma 

## Description

Retrieves the collection images from the api instead of our hardcoded list of images. I am currently falling back to our manually-generated list because the dev site and local development use the dev version of the api:

`https://api-dev.creativecommons.engineering/v1/sources?format=json&limit=500`

which doesn't have all of the images uploaded (they _are_ on the main api though).

## Screenshots
![Screen Shot 2020-07-27 at 15 57 23-fullpage](https://user-images.githubusercontent.com/6351754/88586602-a097f480-d022-11ea-9cd9-fbb9b6d2d2b8.png)




## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
