### PR TITLE
Add Nappy.co to meta image search

### DIFF
--- a/src/components/MetaSearch/MetaSearchCard.vue
+++ b/src/components/MetaSearch/MetaSearchCard.vue
@@ -3,7 +3,7 @@
     <p class="padding-left-bigger padding-right-bigger">
       Click on a source below to directly search other collections of
       CC-licensed images.<br />Please note that Use filters are not supported
-      for Open Clip Art Library.
+      for Open Clip Art Library or Nappy.
     </p>
     <hr class="margin-bottom-bigger" />
     <div

--- a/src/utils/getLegacySourceUrl.js
+++ b/src/utils/getLegacySourceUrl.js
@@ -106,6 +106,16 @@ export const legacySourceMap = {
       }
     },
   },
+  Nappy: {
+    image(search) {
+      return {
+        url: 'https://www.nappy.co/',
+        query: {
+          s: search.q,
+        },
+      }
+    },
+  },
   SoundCloud: {
     audio(search) {
       let license = 'to_share'


### PR DESCRIPTION
Adds https://nappy.co to meta image search.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
