### PR TITLE
Swallow duplicate nav errors

### DIFF
--- a/src/router/redirectTo.js
+++ b/src/router/redirectTo.js
@@ -1,8 +1,17 @@
+/**
+ * Ignore duplicate route errors
+ * @see https://router.vuejs.org/guide/advanced/navigation-failures.html#detecting-navigation-failures
+ */
+const handleRouteErrors = (failure) => {
+  // Until vue-router@3.4.0 comes out, this is how to detect a 'duplicate navigation' error
+  if (failure.type !== 4) throw Error
+}
+
 const redirectTo = (router) => (location, replace = false) => {
   if (replace) {
-    router.replace(location)
+    router.replace(location).catch(handleRouteErrors)
   } else {
-    router.push(location)
+    router.push(location).catch(handleRouteErrors)
   }
 }
 

--- a/test/unit/specs/router/redirectTo.spec.js
+++ b/test/unit/specs/router/redirectTo.spec.js
@@ -2,8 +2,8 @@ import redirectTo from '@/router/redirectTo'
 
 describe('redirectTo', () => {
   const routerMock = {
-    push: jest.fn(),
-    replace: jest.fn(),
+    push: jest.fn(() => Promise.resolve()),
+    replace: jest.fn(() => Promise.resolve()),
   }
   const redirect = redirectTo(routerMock)
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #1042 by @zackkrida 

Stops the throwing of `NavigationDuplicated` errors, as these are valid in our app and don't pose a problem. 


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
