### PR TITLE
Fix faulty conditional that prevented source logos from loading

### DIFF
--- a/src/components/CollectionItem.vue
+++ b/src/components/CollectionItem.vue
@@ -44,14 +44,11 @@ export default {
     },
     getProviderLogo(providerName) {
       const provider = ImageProviderService.getProviderInfo(providerName)
-      if (provider) {
-        const logo = provider.logo
-        const logoUrl = this.provider.logo_url || require(`@/assets/${logo}`) // eslint-disable-line global-require, import/no-dynamic-require
+      const logoUrl =
+        this.provider.logo_url ||
+        (provider ? require(`@/assets/${provider.logo}`) : '') // eslint-disable-line global-require, import/no-dynamic-require
 
-        return logoUrl
-      }
-
-      return ''
+      return logoUrl
     },
   },
 }
@@ -85,5 +82,14 @@ export default {
   img {
     max-height: 10rem;
   }
+}
+
+// Fallback styles in the rare event logos don't display
+.provider-logo img[src=''] {
+  word-wrap: break-word;
+  white-space: pre-line;
+  text-align: center;
+  font-size: 15px;
+  display: block;
 }
 </style>


### PR DESCRIPTION
Fixes displaying source logos from S3, was broken due to some bad/old conditional logic I overlooked.
Also adds styles for img fallback text when images aren't present.

<img width="309" alt="Screen Shot 2020-08-06 at 10 07 32 AM" src="https://user-images.githubusercontent.com/6351754/89543366-d1202100-d7ce-11ea-90b0-022620e81c93.png">
<img width="359" alt="Screen Shot 2020-08-06 at 10 05 31 AM" src="https://user-images.githubusercontent.com/6351754/89543367-d1202100-d7ce-11ea-9173-b3157f6b717f.png">


[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
