### PR TITLE
Make sure global header renders once; Remove max-width restriction on global header tab

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -23,13 +23,16 @@ export default {
     }
   },
   mounted() {
-    // Load voocabulary global header from the unpkg CDN!
+    // Load voocabulary global header from the unpkg CDN and render the global header.
+    // Make sure all of this only happens once.
     if (typeof document !== 'undefined') {
       const el = document.createElement('script')
       el.src = 'https://unpkg.com/@creativecommons/vocabulary/js/vocabulary.js'
       el.defer = true
       el.addEventListener('load', () => {
-        window.vocabulary.createGlobalHeader()
+        if (!document.querySelector('.cc-global-header')) {
+          window.vocabulary.createGlobalHeader()
+        }
       })
       document.head.appendChild(el)
     }
@@ -68,5 +71,10 @@ body {
     position: sticky;
     top: 0;
   }
+}
+
+// override global header styles for now
+.cc-global-header .container {
+  max-width: 100%;
 }
 </style>


### PR DESCRIPTION
Fixes the global header tab to always be aligned with the site menu, and makes sure it only renders once.

> before
<img width="1664" alt="before" src="https://user-images.githubusercontent.com/6351754/89544182-cc0fa180-d7cf-11ea-9b60-90e9c0eb5be0.png">

> after

<img width="1358" alt="after" src="https://user-images.githubusercontent.com/6351754/89544186-ce71fb80-d7cf-11ea-8312-18f811762a55.png">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
