### PR TITLE
Add keypress listener to tooltip img and filter close button

### DIFF
--- a/src/components/Filters/FilterBlock.vue
+++ b/src/components/Filters/FilterBlock.vue
@@ -21,7 +21,11 @@
     :aria-label="label + 'filter'"
   >
     <span>{{ $t(this.$props.label) }}</span>
-    <span class="close padding-left-normal" tabindex="0" @click="onClick"
+    <span
+      class="close padding-left-normal"
+      tabindex="0"
+      @click="onClick"
+      v-on:keyup.enter="onClick"
       ><i class="icon cross"
     /></span>
   </button>

--- a/src/components/Filters/FilterChecklist.vue
+++ b/src/components/Filters/FilterChecklist.vue
@@ -49,6 +49,7 @@
           alt="help"
           class="license-help is-pulled-right padding-top-smallest padding-right-smaller"
           @click.stop="toggleLicenseExplanationVisibility(item.code)"
+          v-on:keyup.enter="toggleLicenseExplanationVisibility(item.code)"
         />
 
         <license-explanation-tooltip


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #1106  by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
Fixes the issue where the license explanation tooltip and the close button on filter tags were not listening to an *enter* keypress.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Added the ```v-on:keyup.enter``` attribute to enable listeners for an *enter* keypress

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
