### PR TITLE
Source and Provider name fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6063,6 +6063,11 @@
         "rsvp": "^4.8.4"
       }
     },
+    "case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ=="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "axios": "^0.18.0",
     "build-url": "^2.0.0",
     "bulma": "^0.8.0",
+    "case": "^1.6.3",
     "clipboard": "^2.0.4",
     "delayed-scroll-restoration-polyfill": "^0.1.1",
     "express": "^4.17.1",

--- a/src/utils/getProviderName.js
+++ b/src/utils/getProviderName.js
@@ -1,11 +1,13 @@
+import { capital } from 'case'
+
 export default function getProviderName(providersList, providerCode) {
   if (!providersList) {
-    return ''
+    return capital(providerCode) || ''
   }
 
   const provider = providersList.filter(
     (p) => p.source_name === providerCode
   )[0]
 
-  return provider ? provider.display_name : ''
+  return provider ? provider.display_name : capital(providerCode) || ''
 }


### PR DESCRIPTION
If a source or provider name isn't in the providers api route, we will fallback to formatting the 'ugly' provider slug from the api.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
