### PR TITLE
Feature/fix visual regressions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,6 +67,7 @@ body {
 
 .full-height-sticky {
   @include desktop {
+    z-index: 20;
     height: 100vh;
     position: sticky;
     top: 0;

--- a/src/components/ImageDetails/CopyLicense.vue
+++ b/src/components/ImageDetails/CopyLicense.vue
@@ -3,7 +3,7 @@
     <h5 class="b-header margin-bottom-small">
       {{ $t('photo-details.reuse.copy-license.title') }}
     </h5>
-    <section class="tabs">
+    <section class="tabs is-boxed">
       <ul role="tablist">
         <li
           role="tab"
@@ -49,7 +49,7 @@
         </li>
       </ul>
     </section>
-    <section class="tabs-content has-background-white padding-normal">
+    <section class="tabs-content is-boxed">
       <div :class="tabClass(0, 'tabs-panel')">
         <span
           id="attribution"
@@ -198,8 +198,5 @@ textarea {
 
 .copy-attribution {
   margin-left: auto;
-}
-.tabs {
-  margin-bottom: 0;
 }
 </style>

--- a/src/components/ImageDetails/ImageAttribution.vue
+++ b/src/components/ImageDetails/ImageAttribution.vue
@@ -2,9 +2,7 @@
   <section class="sidebar_section">
     <div
       class="photo-attribution margin-bottom-big"
-      v-if="
-        (fullLicenseName === 'cc0 1.0') | (fullLicenseName === 'CC pdm 1.0')
-      "
+      v-if="fullLicenseName.includes('cc0') || fullLicenseName.includes('pdm')"
     >
       <h5 class="b-header margin-bottom-big">
         {{ $t('photo-details.reuse.license-header') }}


### PR DESCRIPTION
Fixes some small visual issues introduced in the last release:

- 'credit the creator' tabs are fixed to use the boxed tab style as seen in figma
- license popovers were covered by image results in one of our filter a/b test variants. fixed!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
