### PR TITLE
Store filter sidebar toggle state in localstorage

### DIFF
--- a/src/store/filter-store.js
+++ b/src/store/filter-store.js
@@ -1,5 +1,6 @@
 import findIndex from 'lodash.findindex'
 import { ExperimentData } from '@/abTests/experiments/filterExpansion'
+import local from '../utils/local'
 import { TOGGLE_FILTER, CONVERT_AB_TEST_EXPERIMENT } from './action-types'
 import {
   SET_FILTER,
@@ -76,8 +77,9 @@ export const filterData = {
   mature: false,
 }
 
+const FILTER_STATE_STORAGE_KEY = 'ccsearch-filter-visibility'
 const MIN_SCREEN_WIDTH_FILTER_VISIBLE_BY_DEFAULT = 800
-const hideFiltersIfMobileScreen = () =>
+const isDesktop = () =>
   screenWidth() > MIN_SCREEN_WIDTH_FILTER_VISIBLE_BY_DEFAULT
 
 const isFilterApplied = (filters) =>
@@ -91,10 +93,15 @@ const isFilterApplied = (filters) =>
     return filters[filterKey].some((filter) => filter.checked)
   })
 
+const localfilterState = () =>
+  local.get(FILTER_STATE_STORAGE_KEY)
+    ? local.get(FILTER_STATE_STORAGE_KEY) === 'true'
+    : true
+
 const initialState = (searchParams) => {
   const filters = queryToFilterData(searchParams)
 
-  const isFilterVisible = hideFiltersIfMobileScreen()
+  const isFilterVisible = isDesktop() ? localfilterState() : false
   const filtersApplied = isFilterApplied(filters)
   return {
     filters,
@@ -186,6 +193,7 @@ const mutations = (redirect) => ({
   },
   [SET_FILTER_IS_VISIBLE](state, params) {
     state.isFilterVisible = params.isFilterVisible
+    local.set(FILTER_STATE_STORAGE_KEY, params.isFilterVisible)
   },
 })
 

--- a/src/utils/local.js
+++ b/src/utils/local.js
@@ -1,0 +1,15 @@
+// Small wrapper for localstorage to protect against SSR
+
+const localStorageExists =
+  typeof window !== 'undefined' && 'localStorage' in window
+
+const local = {
+  get(key) {
+    return localStorageExists ? localStorage.getItem(key) : null
+  },
+  set(key, value) {
+    return localStorageExists ? localStorage.setItem(key, value) : null
+  },
+}
+
+export default local


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #506 by @annatuma 

Stores the open/close state of the filter sidebar in localstorage for desktop users. This means on repeat visits to the `/search` page the user's previous sidebar state will be respected.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
