### PR TITLE
Fix codeowners files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @creativecommons/ct-cc-search-core-committers @creativecommons/ct-cc-search-collaborators
+* @creativecommons/frontend @creativecommons/ct-cc-search-core-committers @creativecommons/ct-cc-search-collaborators

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+.github
 dist

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @creativecommons/frontend @creativecommons/ct-cc-search-core-committers @creativecommons/ct-cc-search-collaborators

--- a/package.json
+++ b/package.json
@@ -150,6 +150,6 @@
   },
   "lint-staged": {
     "*.{js,vue}": "eslint --cache --fix",
-    "*": "prettier --write"
+    "*.{js,vue,css,md}": "prettier --write"
   }
 }


### PR DESCRIPTION
Fixes issues with duplicate codeowners files and moves to more standard location. Updated prettier config because it was trying to format the new codeowners file.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
