### PR TITLE
Fixed plain text attribution typos for tools

### DIFF
--- a/src/components/ImageDetails/CopyLicense.vue
+++ b/src/components/ImageDetails/CopyLicense.vue
@@ -113,9 +113,9 @@
         >
           {{ imageTitle }}
           <span v-if="image.creator"> by {{ image.creator }} </span>
-          is licensed under
+          is marked under
           {{ fullLicenseName.toUpperCase() }}. To
-          {{ isTool ? 'the terms' : 'view a copy of this license' }}, visit
+          {{ isTool ? 'view the terms' : 'view a copy of this license' }}, visit
           <template v-if="licenseURL">
             {{ licenseURL.substring(0, licenseURL.indexOf('?')) }}
           </template>

--- a/src/components/ImageDetails/CopyLicense.vue
+++ b/src/components/ImageDetails/CopyLicense.vue
@@ -113,7 +113,7 @@
         >
           {{ imageTitle }}
           <span v-if="image.creator"> by {{ image.creator }} </span>
-          is marked under
+          {{ isTool ? 'is marked under' : 'is licensed with' }}
           {{ fullLicenseName.toUpperCase() }}. To
           {{ isTool ? 'view the terms' : 'view a copy of this license' }}, visit
           <template v-if="licenseURL">


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1155 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
> Anything marked with **CC0** or **PDM** has two typos in the "Plain text" attribution tab:
> 1. Says "licensed" instead of "marked"
> 2. Says "to the terms" instead of "to view the terms"

Now, the fix resolves these issues as you can see in following screenshot:
![Screenshot from 2020-08-18 11-13-24](https://user-images.githubusercontent.com/35889327/90476349-f570eb80-e146-11ea-9cae-e2c48bb977cd.png)
### Successfully ran all the tests locally after editing:
![Screenshot from 2020-08-18 11-15-03](https://user-images.githubusercontent.com/35889327/90476508-42ed5880-e147-11ea-8f97-6eb715695253.png)


## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
### Previously:
![image](https://user-images.githubusercontent.com/35889327/90476208-a88d1500-e146-11ea-9e28-6b8e4268c041.png)
### Now:
![Screenshot from 2020-08-18 11-13-46](https://user-images.githubusercontent.com/35889327/90476256-c65a7a00-e146-11ea-9990-f3346882d4fa.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
