### PR TITLE
Content Reporting Form cleanup

### DIFF
--- a/src/components/ContentReport/ContentReportForm.vue
+++ b/src/components/ContentReport/ContentReportForm.vue
@@ -10,14 +10,14 @@
     </button>
     <dmca-notice
       v-if="selectedCopyright"
-      :imageURL="imageURL"
+      :imageURL="image.url"
       :providerName="providerName"
       :dmcaFormUrl="dmcaFormUrl"
       @onBackClick="onBackClick()"
     />
     <done-message
       v-else-if="!selectedCopyright && isReportSent"
-      :imageURL="imageURL"
+      :imageURL="image.url"
       :providerName="providerName"
     />
     <report-error v-else-if="reportFailed" />
@@ -76,16 +76,16 @@
         </div>
       </fieldset>
 
-      <span
+      <p
         class="caption has-text-weight-semibold has-text-grey margin-bottom-normal"
       >
         {{ $t('photo-details.content-report.caption') }}
-      </span>
+      </p>
 
       <button
         type="button"
         :disabled="selectedReason === null"
-        class="button next-button tiny is-info is-pulled-right"
+        class="button next-button tiny is-success is-pulled-right"
         @click="onIssueSelected()"
         v-on:keyup.enter="onIssueSelected()"
       >
@@ -96,6 +96,7 @@
 </template>
 
 <script>
+import getProviderName from '@/utils/getProviderName'
 import { SEND_CONTENT_REPORT } from '@/store/action-types'
 import { REPORT_FORM_CLOSED } from '@/store/mutation-types'
 import dmcaNotice from './DmcaNotice'
@@ -108,7 +109,7 @@ const dmcaFormUrl =
 
 export default {
   name: 'content-report-form',
-  props: ['imageId', 'imageURL', 'providerName'],
+  props: ['image'],
   components: {
     DoneMessage,
     dmcaNotice,
@@ -130,6 +131,12 @@ export default {
     reportFailed() {
       return this.$store.state.reportFailed
     },
+    providerName() {
+      return getProviderName(
+        this.$store.state.imageProviders,
+        this.image.provider
+      )
+    },
   },
   methods: {
     onIssueSelected() {
@@ -147,7 +154,7 @@ export default {
     },
     sendContentReport(description = '') {
       this.$store.dispatch(SEND_CONTENT_REPORT, {
-        identifier: this.$props.imageId,
+        identifier: this.$props.image.id,
         reason: this.selectedReason,
         description,
       })

--- a/src/components/ContentReport/DmcaNotice.vue
+++ b/src/components/ContentReport/DmcaNotice.vue
@@ -2,7 +2,7 @@
   <div>
     <i18n
       path="photo-details.content-report.dmca.content"
-      tag="span"
+      tag="p"
       class="is-block padding-horizontal-big margin-top-large has-text-centered"
     >
       <template v-slot:link>
@@ -15,10 +15,11 @@
         >
       </template>
     </i18n>
+
     <i18n
       path="photo-details.content-report.dmca.provider"
-      tag="span"
-      class="is-block padding-horizontal-big margin-top-large has-text-centered"
+      tag="p"
+      class="is-block padding-horizontal-big margin-top-normal has-text-centered"
     >
       <template v-slot:link>
         <a
@@ -27,9 +28,10 @@
           target="_blank"
           rel="noopener"
           >{{ providerName }}</a
-        >.
+        >
       </template>
     </i18n>
+
     <button
       class="button is-text tiny margin-top-normal is-shadowless has-text-grey"
       @click="onBackClick()"

--- a/src/components/ContentReport/OtherIssueForm.vue
+++ b/src/components/ContentReport/OtherIssueForm.vue
@@ -27,7 +27,7 @@
       <button
         type="button"
         :disabled="!descriptionHasMoreThan20Chars"
-        class="button submit-other-button tiny is-info margin-top-normal is-pulled-right"
+        class="button submit-other-button tiny is-success margin-top-normal is-pulled-right"
         @click="sendContentReport()"
         v-on:keyup.enter="sendContentReport()"
       >

--- a/src/components/ImageDetails/PhotoDetails.vue
+++ b/src/components/ImageDetails/PhotoDetails.vue
@@ -32,12 +32,7 @@
         </button>
       </div>
       <div class="margin-top-small has-text-left">
-        <content-report-form
-          v-if="isReportFormVisible"
-          :imageId="image.id"
-          :imageURL="image.foreign_landing_url"
-          :providerName="image.provider"
-        />
+        <content-report-form v-if="isReportFormVisible" :image="image" />
       </div>
     </div>
     <div

--- a/test/unit/specs/components/ContentReport/content-report-form.spec.js
+++ b/test/unit/specs/components/ContentReport/content-report-form.spec.js
@@ -11,8 +11,7 @@ describe('ContentReportForm', () => {
   const $t = (key) => i18n.messages[key]
   beforeEach(() => {
     props = {
-      imageId: 1,
-      imageURL: 'http://foo.bar',
+      image: { id: 1, url: 'http://foo.bar' },
     }
 
     dispatchMock = jest.fn()
@@ -85,7 +84,7 @@ describe('ContentReportForm', () => {
     const button = wrapper.find('.next-button')
     button.trigger('click')
     expect(dispatchMock).toHaveBeenCalledWith('SEND_CONTENT_REPORT', {
-      identifier: props.imageId,
+      identifier: props.image.id,
       reason: 'mature',
       description: '',
     })
@@ -107,7 +106,7 @@ describe('ContentReportForm', () => {
     const description = 'foo bar'
     wrapper.vm.sendContentReport(description)
     expect(dispatchMock).toHaveBeenCalledWith('SEND_CONTENT_REPORT', {
-      identifier: props.imageId,
+      identifier: props.image.id,
       reason: 'other',
       description,
     })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes https://github.com/creativecommons/vocabulary/issues/411 on vocabulary and other issues.

This PR makes some improvements to the content reporting form:

- Removes an extra '.' at the end of the DMCA notice sentence
- Fixes extra spacing between DMCA notice paragraphs
- Fixes 'next' button disabled color
- Shows formatted provider name in DMCA form instead of slug
- Fixes line height of info paragraph

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
