### PR TITLE
Fix meta search query update issues

### DIFF
--- a/src/components/SearchGridForm.vue
+++ b/src/components/SearchGridForm.vue
@@ -27,7 +27,8 @@
               type="search"
               ref="search"
               :placeholder="searchBoxPlaceholder"
-              v-model="searchTermsModel"
+              :value="searchTermsModel"
+              @input="onInput"
               @keyup.enter="onSubmit"
             />
           </label>
@@ -95,6 +96,9 @@ export default {
   name: 'search-grid-form',
   data: () => ({ searchTermsModel: null }),
   computed: {
+    activeTab() {
+      return this.$route.path.split('search/')[1] || 'image'
+    },
     searchTerms() {
       return this.$store.state.query.q
     },
@@ -115,9 +119,22 @@ export default {
       if (this.searchTermsModel) {
         this.$emit('onSearchFormSubmit', {
           query: { q: this.searchTermsModel },
-          shouldNavigate: true,
         })
         this.$refs.search.blur()
+      }
+    },
+    /**
+     * If we're on the audio or video tab, we want to set the search query on change
+     * rather than on submit, so the meta search buttons update live witout the user
+     * having to manually submit a new search term.
+     */
+    onInput(e) {
+      this.searchTermsModel = e.target.value
+
+      if (this.activeTab === 'video' || this.activeTab === 'audio') {
+        this.$emit('onSearchFormSubmit', {
+          query: { q: this.searchTermsModel },
+        })
       }
     },
     onToggleSearchGridFilter() {

--- a/src/store/search-store.js
+++ b/src/store/search-store.js
@@ -216,7 +216,7 @@ const mutations = (redirect) => ({
     _state.imagePage = params.page || 1
   },
   [SET_QUERY](_state, params) {
-    setQuery(_state, params, '/search', redirect)
+    setQuery(_state, params, window.location.pathname, redirect)
   },
   [IMAGE_NOT_FOUND]() {
     redirect({ path: '/not-found' }, true)

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -146,7 +146,7 @@ describe('Search Store', () => {
       mutations[SET_QUERY](state, params)
 
       expect(routePushMock).toBeCalledWith({
-        path: '/search',
+        path: '/',
         query: params.query,
       })
     })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1161 by @annatuma 

- Removes redirect to image results when clicking "search" button on audio|video tabs
- "Live" updates meta search buttons when the user types in the search input on audio|video tabs
	- Note this functionality was already working for meta image search

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
