### PR TITLE
Fix failed redirection on homepage search input

### DIFF
--- a/src/store/search-store.js
+++ b/src/store/search-store.js
@@ -40,6 +40,11 @@ const initialState = (searchParams) => {
   }
 }
 
+const getSearchPath = () =>
+  window.location.pathname && window.location.pathname.includes('search')
+    ? window.location.pathname
+    : '/search'
+
 /**
  * hides the search results in case the user is performing a new search.
  * This prevents results from a previous search from showing while the
@@ -216,7 +221,7 @@ const mutations = (redirect) => ({
     _state.imagePage = params.page || 1
   },
   [SET_QUERY](_state, params) {
-    setQuery(_state, params, window.location.pathname, redirect)
+    setQuery(_state, params, getSearchPath(), redirect)
   },
   [IMAGE_NOT_FOUND]() {
     redirect({ path: '/not-found' }, true)


### PR DESCRIPTION
Fixes a devsite bug where the homepage search input doesn't actually submit. As this is fairly critical and affects folks' ability to test on the devsite, I'll push this and get a retroactive code review.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
