### PR TITLE
Safer browsing language update

### DIFF
--- a/src/components/SaferBrowsing.vue
+++ b/src/components/SaferBrowsing.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="safe-browsing" @keyup.esc="closeShowForm">
+  <div class="safer-browsing" @keyup.esc="closeShowForm">
     <button
       class="button is-text tiny is-paddingless rating is-shadowless"
       @click="toggleShowForm"
     >
       <span class="has-color-dark-turquoise"
-        >{{ $t('browse-page.safe-browsing.title')
+        >{{ $t('browse-page.safer-browsing.title')
         }}<i class="icon flag margin-left-small"></i>
       </span>
     </button>
@@ -21,7 +21,7 @@
           <i class="icon cross"></i>
         </button>
         <p class="caption has-text-weight-semibold padding-right-big">
-          {{ $t('browse-page.safe-browsing.caption') }}
+          {{ $t('browse-page.safer-browsing.caption') }}
         </p>
 
         <label class="checkbox margin-top-small" for="mature">
@@ -33,7 +33,7 @@
             @change="toggleMature"
             @keyup.enter="toggleMature"
           />
-          {{ $t('browse-page.safe-browsing.label') }}
+          {{ $t('browse-page.safer-browsing.label') }}
         </label>
       </div>
     </focus-trap>
@@ -48,7 +48,7 @@ import { FocusTrap } from 'focus-trap-vue'
  * This component displays the mature content filter in a pop-up dialog.
  */
 export default {
-  name: 'safe-browsing',
+  name: 'safer-browsing',
   components: {
     FocusTrap,
   },
@@ -80,11 +80,11 @@ export default {
 </script>
 
 <style>
-.safe-browsing {
+.safer-browsing {
   position: relative;
 }
 
-.safe-browsing > .button.tiny {
+.safer-browsing > .button.tiny {
   font-size: 0.8rem;
 }
 </style>

--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -17,7 +17,7 @@
         <div class="is-hidden-desktop is-block">
           <search-rating v-if="_query.q" :searchTerm="searchTerm" />
         </div>
-        <safe-browsing />
+        <safer-browsing />
       </div>
       <div class="search-grid-cells">
         <search-grid-cell
@@ -77,7 +77,7 @@ import { SET_IMAGES } from '@/store/mutation-types'
 import SearchGridCell from '@/components/SearchGridCell'
 import LoadingIcon from '@/components/LoadingIcon'
 import SearchRating from '@/components/SearchRating'
-import SafeBrowsing from '@/components/SafeBrowsing'
+import SaferBrowsing from '@/components/SaferBrowsing'
 import MetaSearchCard from '@/components/MetaSearch/MetaSearchCard'
 import AppModal from '@/components/AppModal'
 
@@ -89,7 +89,7 @@ export default {
     SearchGridCell,
     LoadingIcon,
     SearchRating,
-    SafeBrowsing,
+    SaferBrowsing,
     MetaSearchCard,
     AppModal,
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -284,8 +284,8 @@
       "cc0": "This work has been marked as dedicated to the public domain.",
       "pdm": "This work is marked as being in the public domain."
     },
-    "safe-browsing": {
-      "title": "Safe Browsing",
+    "safer-browsing": {
+      "title": "Safer Browsing",
       "caption": "By default, search results will not include results that have been reported as mature by users and sources.",
       "label": "Show Mature Content"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -256,8 +256,8 @@
       "cc0": "Ce travail a été marqué comme dédié au domaine public.",
       "pdm": "Ce travail est marqué comme étant dans le domaine public."
     },
-    "safe-browsing": {
-      "title": "Navigation sûre",
+    "safer-browsing": {
+      "title": "Navigation plus sûre",
       "caption": "Par défaut, les résultats de recherche n'incluront pas les résultats signalés comme matures par les utilisateurs et les sources.",
       "label": "Afficher le contenu mature"
     },


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1185 by @TimidRobot 

Replaces "safe browsing" with the more accurate "safer browsing" in the front end. 
Also renames components and labels internally in the repo with this revised language.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
