### PR TITLE
Fix asset paths on Meta Search Page

### DIFF
--- a/src/pages/MetaSearchPage.vue
+++ b/src/pages/MetaSearchPage.vue
@@ -9,7 +9,7 @@
           </h1>
           <i18n path="meta-search-page.intro" tag="p">
             <template v-slot:link>
-              <a aria-label="sources" href="./sources">sources</a>
+              <a aria-label="sources" href="/sources">sources</a>
             </template>
           </i18n>
         </div>
@@ -44,7 +44,7 @@
         </i18n>
         <figure class="image margin-vertical-large">
           <img
-            src="src/assets/meta-search-images.gif"
+            src="@/assets/meta-search-images.gif"
             alt="Meta Search Images - Cars"
           />
         </figure>
@@ -63,7 +63,7 @@
         </i18n>
         <figure class="image margin-vertical-large">
           <img
-            src="src/assets/meta-search-audio.gif"
+            src="@/assets/meta-search-audio.gif"
             alt="Meta Search Audio - Drums"
           />
         </figure>
@@ -96,7 +96,7 @@
         <p>{{ $t('meta-search-page.why.content') }}</p>
         <figure class="image margin-vertical-large">
           <img
-            src="src/assets/cc-meta-search.gif"
+            src="@/assets/cc-meta-search.gif"
             alt="Old CC Meta Search Portal Demo"
           />
         </figure>


### PR DESCRIPTION
Fixes broken images on the meta search page. Image paths were only working locally.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
