### PR TITLE
Support analytics and style cleanup

### DIFF
--- a/src/analytics/events.js
+++ b/src/analytics/events.js
@@ -11,3 +11,11 @@ export function EmbedAttribution() {
 export function SocialMediaShare(site) {
   return new Event('Social Media', 'Share', site)
 }
+
+export function DonateLinkClick(location) {
+  return new Event('Donation', 'Click', location)
+}
+
+export function DonateBannerClose() {
+  return new Event('Donation', 'Close')
+}

--- a/src/components/DonationBanner.vue
+++ b/src/components/DonationBanner.vue
@@ -9,6 +9,7 @@
         href="https://www.classy.org/give/297881/#!/donation/checkout"
         target="_blank"
         class="button is-success small"
+        @click="sendClickEvent"
       >
         <i
           class="icon cc-letterheart-filled margin-right-small is-size-5 padding-top-smaller"
@@ -23,11 +24,18 @@
 </template>
 
 <script>
+import GoogleAnalytics from '@/analytics/GoogleAnalytics'
+import { DonateLinkClick, DonateBannerClose } from '@/analytics/events'
+
 export default {
   name: 'DonationBanner',
   methods: {
     onDismiss() {
       this.$emit('onDismiss')
+      GoogleAnalytics().sendEvent(DonateBannerClose())
+    },
+    sendClickEvent() {
+      GoogleAnalytics().sendEvent(DonateLinkClick('banner'))
     },
   },
 }

--- a/src/components/FooterSection.vue
+++ b/src/components/FooterSection.vue
@@ -149,6 +149,7 @@
             <a
               class="button small donate"
               href="http://creativecommons.org/donate"
+              @click="sendClickEvent"
             >
               <i
                 class="icon cc-letterheart-filled margin-right-small is-size-5 padding-top-smaller"
@@ -163,8 +164,16 @@
 </template>
 
 <script>
+import GoogleAnalytics from '@/analytics/GoogleAnalytics'
+import { DonateLinkClick } from '@/analytics/events'
+
 export default {
   name: 'footer-section',
+  methods: {
+    sendClickEvent() {
+      GoogleAnalytics().sendEvent(DonateLinkClick('footer'))
+    },
+  },
 }
 </script>
 

--- a/src/pages/SupportPage.vue
+++ b/src/pages/SupportPage.vue
@@ -30,6 +30,7 @@
                 </div>
                 <a
                   class="button normal donate margin-right-normal"
+                  @click="sendDonationEvent"
                   :href="donationLink"
                 >
                   <i
@@ -108,7 +109,11 @@
             </template>
           </i18n>
           <div class="field button-row">
-            <a class="button normal donate" :href="donationLink">
+            <a
+              @click="sendDonationEvent"
+              class="button normal donate"
+              :href="donationLink"
+            >
               <i
                 class="icon cc-letterheart-filled margin-right-small padding-top-smaller"
               ></i>
@@ -184,7 +189,11 @@
             {{ $t('support.future.support') }}
           </h2>
           <div class="field button-row margin-bottom-medium">
-            <a class="button normal donate" :href="donationLink">
+            <a
+              class="button normal donate"
+              @click="sendDonationEvent"
+              :href="donationLink"
+            >
               <i
                 class="icon cc-letterheart-filled margin-right-small padding-top-smaller"
               ></i>
@@ -203,6 +212,8 @@
 import HeaderSection from '@/components/HeaderSection'
 import FooterSection from '@/components/FooterSection'
 import ServerPrefetchProvidersMixin from '@/pages/mixins/ServerPrefetchProvidersMixin'
+import GoogleAnalytics from '@/analytics/GoogleAnalytics'
+import { DonateLinkClick } from '@/analytics/events'
 
 const MetaSearchPage = {
   name: 'meta-search-page',
@@ -215,6 +226,11 @@ const MetaSearchPage = {
     return {
       donationLink: 'https://www.classy.org/give/297881/#!/donation/checkout',
     }
+  },
+  methods: {
+    sendDonationEvent() {
+      GoogleAnalytics().sendEvent(DonateLinkClick('support-page'))
+    },
   },
 }
 


### PR DESCRIPTION
This PR fixes a spacing bug with the 'Not today' button on the donation banner. It also adds Google analytics events for:

- Clicks of donation links on the site
- Dismissal of the donation banner (can give us a sense of how "annoying" people find this)

Goals have been created for these events:

<img width="262" alt="Screen Shot 2020-09-24 at 4 32 44 PM" src="https://user-images.githubusercontent.com/6351754/94220176-1df5af00-fe84-11ea-9973-bd6d600b5405.png">

The "Donation Link Click" goal can be further filtered by the event 'label' in google analytics, which will be one of the following values:

- `banner` The click was the donate button inside the donate header banner
- `footer` The click was from the donate button in the site's footer
- `support-page` The click was one of the many buttons on the support page

In general, this isn't a perfect implementation code-wise, and should be improved in a bigger refactor of how analytics is set up in the app. I will make a ticket for that when there's sufficient time!


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
