### PR TITLE
Register Creator and Image source clicks with Analitics API

### DIFF
--- a/src/components/ImageDetails/CopyLicense.vue
+++ b/src/components/ImageDetails/CopyLicense.vue
@@ -56,9 +56,14 @@
           class="photo_usage-attribution is-block"
           ref="photoAttribution"
         >
-          <a :href="image.foreign_landing_url" target="_blank" rel="noopener">{{
-            imageTitle
-          }}</a>
+          <a
+            :href="image.foreign_landing_url"
+            target="_blank"
+            rel="noopener"
+            @click="onPhotoSourceLinkClicked"
+            v-on:keyup.enter="onPhotoSourceLinkClicked"
+            >{{ imageTitle }}</a
+          >
           <span v-if="image.creator">
             by
             <a
@@ -66,6 +71,8 @@
               :href="image.creator_url"
               target="_blank"
               rel="noopener"
+              @click="onPhotoCreatorLinkClicked"
+              v-on:keyup.enter="onPhotoCreatorLinkClicked"
               >{{ image.creator }}</a
             >
             <span v-else>{{ image.creator }}</span>
@@ -182,6 +189,18 @@ export default {
     onCopyAttribution(type, event) {
       this.$store.dispatch(COPY_ATTRIBUTION, { type, content: event.content })
       this.sendDetailPageEvent(DETAIL_PAGE_EVENTS.ATTRIBUTION_CLICKED)
+    },
+    onPhotoSourceLinkClicked() {
+      this.$store.dispatch(SEND_DETAIL_PAGE_EVENT, {
+        eventType: DETAIL_PAGE_EVENTS.SOURCE_CLICKED,
+        resultUuid: this.$props.image.id,
+      })
+    },
+    onPhotoCreatorLinkClicked() {
+      this.$store.dispatch(SEND_DETAIL_PAGE_EVENT, {
+        eventType: DETAIL_PAGE_EVENTS.CREATOR_CLICKED,
+        resultUuid: this.$props.image.id,
+      })
     },
   },
 }

--- a/src/components/ImageDetails/ImageInfo.vue
+++ b/src/components/ImageDetails/ImageInfo.vue
@@ -23,6 +23,8 @@
             :href="image.foreign_landing_url"
             target="blank"
             rel="noopener noreferrer"
+            @click="onPhotoSourceLinkClicked"
+            v-on:keyup.enter="onPhotoSourceLinkClicked"
           >
             {{ sourceName }}
           </a>
@@ -42,6 +44,10 @@
 import PhotoTags from '@/components/PhotoTags'
 import getProviderName from '@/utils/getProviderName'
 import getProviderLogo from '@/utils/getProviderLogo'
+import {
+  SEND_DETAIL_PAGE_EVENT,
+  DETAIL_PAGE_EVENTS,
+} from '@/store/usage-data-analytics-types'
 
 export default {
   name: 'image-info',
@@ -79,6 +85,12 @@ export default {
   methods: {
     getProviderLogo(providerName) {
       return getProviderLogo(providerName)
+    },
+    onPhotoSourceLinkClicked() {
+      this.$store.dispatch(SEND_DETAIL_PAGE_EVENT, {
+        eventType: DETAIL_PAGE_EVENTS.SOURCE_CLICKED,
+        resultUuid: this.$props.image.id,
+      })
     },
   },
 }

--- a/src/components/ImageDetails/PhotoDetails.vue
+++ b/src/components/ImageDetails/PhotoDetails.vue
@@ -48,6 +48,8 @@
             :aria-label="'author' + image.creator"
             v-if="image.creator_url"
             :href="image.creator_url"
+            @click="onPhotoCreatorLinkClicked"
+            v-on:keyup.enter="onPhotoCreatorLinkClicked"
           >
             {{ image.creator }}
           </a>
@@ -231,6 +233,12 @@ export default {
     onPhotoSourceLinkClicked() {
       this.$store.dispatch(SEND_DETAIL_PAGE_EVENT, {
         eventType: DETAIL_PAGE_EVENTS.SOURCE_CLICKED,
+        resultUuid: this.$props.image.id,
+      })
+    },
+    onPhotoCreatorLinkClicked() {
+      this.$store.dispatch(SEND_DETAIL_PAGE_EVENT, {
+        eventType: DETAIL_PAGE_EVENTS.CREATOR_CLICKED,
         resultUuid: this.$props.image.id,
       })
     },


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1237 by @aldenstpage 

<!-- Concisely describe what the pull request does. -->
Currently we track when users click on big green "Go to image's website" button  and are redirected to an external URL.

However, the same link to an external URL of the image source exists in two other places: in the Rich text attribution box and in the Information Tab. There is also a link to creator profile below the image title and in the Rich text attribution box. I added action to send image id to the Analytics API when users click on any of these links.

## Screenshots

![ExternalLinksTracking](https://user-images.githubusercontent.com/15233243/95197222-f2f34f80-07e1-11eb-9870-eb80bdd7ef81.png)

![Information Tab](https://user-images.githubusercontent.com/15233243/95197362-2cc45600-07e2-11eb-8c00-a0a3c0bf1a7e.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
