### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @creativecommons/frontend @creativecommons/ct-cc-search-core-committers @creativecommons/ct-cc-search-collaborators
+* @creativecommons/ct-cc-search-maintainers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.